### PR TITLE
chore: Fix some warnings in the move packages

### DIFF
--- a/packages/iota-names/sources/controller.move
+++ b/packages/iota-names/sources/controller.move
@@ -81,7 +81,7 @@ entry fun set_user_data(
     let domain = nft.domain();
 
     registry.assert_nft_is_authorized(nft, clock);
-    let key_bytes = *key.bytes();
+    let key_bytes = *key.as_bytes();
     assert!(key_bytes == AVATAR || key_bytes == CONTENT_HASH, EUnsupportedKey);
 
     if (data.contains(&key)) {

--- a/packages/iota-names/sources/domain.move
+++ b/packages/iota-names/sources/domain.move
@@ -132,7 +132,7 @@ fun validate_labels(labels: &vector<String>) {
 
 fun is_valid_label(label: &String): bool {
     let len = label.length();
-    let label_bytes = label.bytes();
+    let label_bytes = label.as_bytes();
     let mut index = 0;
 
     if (!(len >= MIN_LABEL_LENGTH && len <= MAX_LABEL_LENGTH)) {
@@ -163,7 +163,7 @@ fun split_by_dot(mut s: String): vector<String> {
     let mut parts: vector<String> = vector[];
     while (!s.is_empty()) {
         let index_of_next_dot = s.index_of(&dot);
-        let part = s.sub_string(0, index_of_next_dot);
+        let part = s.substring(0, index_of_next_dot);
         parts.push_back(part);
 
         let len = s.length();
@@ -173,7 +173,7 @@ fun split_by_dot(mut s: String): vector<String> {
             index_of_next_dot + 1
         };
 
-        s = s.sub_string(start_of_next_part, len);
+        s = s.substring(start_of_next_part, len);
     };
 
     parts


### PR DESCRIPTION
## Description

Fixes a few instances of `bytes()` and `sub_string()` which are deprecated.

Closes #2