### PR TITLE
fix: e2e tests, disable mainnet and testnet for now

### DIFF
--- a/scripts/init/packages.ts
+++ b/scripts/init/packages.ts
@@ -37,7 +37,7 @@ const parseCreatedObject = (data: IotaTransactionBlockResponse, objectType: stri
 };
 
 export const Packages = (network: Network) => {
-	const rev = network === 'localnet' ? 'main' : `framework/${network}`;
+	const rev = network === 'localnet' ? 'develop' : `framework/${network}`;
 	const subdomainExtraDependencies = `denylist = { local = "../denylist" }`;
 
 	return {

--- a/sdk/test/live.test.ts
+++ b/sdk/test/live.test.ts
@@ -2,18 +2,21 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 
-import { e2eLiveNetworkDryRunFlow } from './pre-built';
+// import { e2eLiveNetworkDryRunFlow } from './pre-built';
 
 describe('it should work on live networks', () => {
-	it('should work on mainnet', async () => {
-		const res = await e2eLiveNetworkDryRunFlow('mainnet');
-		expect(res.effects.status.status).toEqual('success');
-	});
+	// TODO: enable when it's deployed on mainnet
+	// 	it('should work on mainnet', async () => {
+	// 		const res = await e2eLiveNetworkDryRunFlow('mainnet');
+	// 		expect(res.effects.status.status).toEqual('success');
+	// 	});
 
-	it('should work on testnet', async () => {
-		const res = await e2eLiveNetworkDryRunFlow('testnet');
-		expect(res.effects.status.status).toEqual('success');
+	it('TODO: should work on testnet', async () => {
+		// TODO: enable when it's deployed on testnet
+		// Commented here as it would otherwise error with `Error: No test found in suite it should work on live networks`
+		// 		const res = await e2eLiveNetworkDryRunFlow('testnet');
+		// 		expect(res.effects.status.status).toEqual('success');
 	});
 });


### PR DESCRIPTION
Use default `develop` branch instead of not existing `main` for localnet and disable mainnet and testnet for now as we don't have it deployed there
Fixes https://github.com/iotaledger/iota-names/issues/67

Tested by running `iota start --with-faucet --force-regenesis --epoch-duration-ms 120000` and `pnpm test:e2e`