### PR TITLE
feat(iota-names)!: remove consts and public funs that aren't required

### DIFF
--- a/packages/iota-names/sources/constants.move
+++ b/packages/iota-names/sources/constants.move
@@ -11,12 +11,6 @@ module iota_names::constants;
 
 use std::string::String;
 
-/// The amount of NANOS in 1 IOTA.
-const NANOS_PER_IOTA: u64 = 1_000_000_000;
-/// The minimum length of a domain name.
-const MIN_DOMAIN_LENGTH: u8 = 3;
-/// The maximum length of a domain name.
-const MAX_DOMAIN_LENGTH: u8 = 63;
 /// Top level domain for IOTA.
 const IOTA_TLD: vector<u8> = b"iota";
 /// The amount of milliseconds in a year.
@@ -49,15 +43,6 @@ public fun iota_tld(): String { IOTA_TLD.to_string() }
 
 /// Default value for the image_url.
 public fun default_image(): String { DEFAULT_IMAGE.to_string() }
-
-/// The amount of NANOS in 1 IOTA.
-public fun nanos_per_iota(): u64 { NANOS_PER_IOTA }
-
-/// The minimum length of a domain name.
-public fun min_domain_length(): u8 { MIN_DOMAIN_LENGTH }
-
-/// The maximum length of a domain name.
-public fun max_domain_length(): u8 { MAX_DOMAIN_LENGTH }
 
 /// The amount of milliseconds in a year.
 public fun year_ms(): u64 { YEAR_MS }

--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -227,8 +227,6 @@ public struct Test has drop {}
 
 #[test_only]
 const NANOS_PER_IOTA: u64 = 1_000_000_000;
-#[test_only]
-public fun nanos_per_iota(): u64 { NANOS_PER_IOTA }
 
 #[test_only]
 public fun new_for_testing(ctx: &mut TxContext): (IotaNames, AdminCap) {
@@ -263,9 +261,9 @@ public fun new_pricing_config(): PricingConfig {
     let range2 = new_range(vector[4, 4]);
     let range3 = new_range(vector[5, 63]);
     let prices = vector[
-        1200 * nanos_per_iota(),
-        200 * nanos_per_iota(),
-        50 * nanos_per_iota(),
+        1200 * NANOS_PER_IOTA,
+        200 * NANOS_PER_IOTA,
+        50 * NANOS_PER_IOTA,
     ];
 
     pricing_config::new(

--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -226,6 +226,11 @@ use iota_names::pricing_config::{Self, new_range, PricingConfig};
 public struct Test has drop {}
 
 #[test_only]
+const NANOS_PER_IOTA: u64 = 1_000_000_000;
+#[test_only]
+public fun nanos_per_iota(): u64 { NANOS_PER_IOTA }
+
+#[test_only]
 public fun new_for_testing(ctx: &mut TxContext): (IotaNames, AdminCap) {
     (IotaNames { id: object::new(ctx), balance: balance::zero() }, AdminCap { id: object::new(ctx) })
 }
@@ -258,9 +263,9 @@ public fun new_pricing_config(): PricingConfig {
     let range2 = new_range(vector[4, 4]);
     let range3 = new_range(vector[5, 63]);
     let prices = vector[
-        1200 * iota_names::constants::nanos_per_iota(),
-        200 * iota_names::constants::nanos_per_iota(),
-        50 * iota_names::constants::nanos_per_iota(),
+        1200 * nanos_per_iota(),
+        200 * nanos_per_iota(),
+        50 * nanos_per_iota(),
     ];
 
     pricing_config::new(

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -13,14 +13,14 @@ use iota::iota::IOTA;
 use iota::test_scenario::{Self, Scenario, ctx};
 use iota::test_utils::{assert_eq, destroy};
 use iota::vec_map::VecMap;
-use iota_names::constants::{nanos_per_iota, year_ms};
+use iota_names::constants::{ year_ms};
 use iota_names::controller::{Self, Controller};
 use iota_names::domain::{Self, Domain};
 use iota_names::register::Register;
 use iota_names::register_utils::register_util;
 use iota_names::registry::{Self, Registry, lookup, reverse_lookup};
 use iota_names::subdomain_registration;
-use iota_names::iota_names::{Self, IotaNames, AdminCap};
+use iota_names::iota_names::{Self, IotaNames, AdminCap, nanos_per_iota};
 use iota_names::iota_names_registration::{Self, IotaNamesRegistration};
 
 use fun set_target_address_util as Scenario.set_target_address_util;

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -20,7 +20,7 @@ use iota_names::register::Register;
 use iota_names::register_utils::register_util;
 use iota_names::registry::{Self, Registry, lookup, reverse_lookup};
 use iota_names::subdomain_registration;
-use iota_names::iota_names::{Self, IotaNames, AdminCap, nanos_per_iota};
+use iota_names::iota_names::{Self, IotaNames, AdminCap, NANOS_PER_IOTA};
 use iota_names::iota_names_registration::{Self, IotaNamesRegistration};
 
 use fun set_target_address_util as Scenario.set_target_address_util;
@@ -72,7 +72,7 @@ fun setup(scenario: &mut Scenario, sender: address, clock_tick: u64) {
         scenario,
         DOMAIN_NAME.to_string(),
         1,
-        1200 * nanos_per_iota(),
+        1200 * NANOS_PER_IOTA,
         clock_tick,
     );
     transfer::public_transfer(nft, sender);

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -13,7 +13,7 @@ use iota::iota::IOTA;
 use iota::test_scenario::{Self, Scenario, ctx};
 use iota::test_utils::{assert_eq, destroy};
 use iota::vec_map::VecMap;
-use iota_names::constants::{ year_ms};
+use iota_names::constants::{year_ms};
 use iota_names::controller::{Self, Controller};
 use iota_names::domain::{Self, Domain};
 use iota_names::register::Register;

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -20,7 +20,7 @@ use iota_names::register::Register;
 use iota_names::register_utils::register_util;
 use iota_names::registry::{Self, Registry, lookup, reverse_lookup};
 use iota_names::subdomain_registration;
-use iota_names::iota_names::{Self, IotaNames, AdminCap, NANOS_PER_IOTA};
+use iota_names::iota_names::{Self, IotaNames, AdminCap};
 use iota_names::iota_names_registration::{Self, IotaNamesRegistration};
 
 use fun set_target_address_util as Scenario.set_target_address_util;
@@ -42,6 +42,7 @@ const SECOND_ADDRESS: address = @0xB002;
 const DOMAIN_NAME: vector<u8> = b"abc.iota";
 const AVATAR: vector<u8> = b"avatar";
 const CONTENT_HASH: vector<u8> = b"content_hash";
+const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 fun test_init(): Scenario {
     let mut scenario_val = test_scenario::begin(IOTA_NAMES_ADDRESS);

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -13,7 +13,7 @@ use iota::iota::IOTA;
 use iota::test_scenario::{Self, Scenario, ctx};
 use iota::test_utils::{assert_eq, destroy};
 use iota::vec_map::VecMap;
-use iota_names::constants::{year_ms};
+use iota_names::constants::year_ms;
 use iota_names::controller::{Self, Controller};
 use iota_names::domain::{Self, Domain};
 use iota_names::register::Register;


### PR DESCRIPTION
Remove consts and public funs that aren't required

Fixes https://github.com/iotaledger/iota-names/issues/56