### PR TITLE
feat: add reverseRegistryTableId to PackageInfo

### DIFF
--- a/documentation/pages/developer/sdk.mdx
+++ b/documentation/pages/developer/sdk.mdx
@@ -82,6 +82,7 @@ const iotaNamesClient = new IotaNamesClient({
         registrationPackageId: '0x9d451fa0139fef8f7c1f0bd5d7e45b7fa9dbb84c2e63c2819c7abd0a7f7d749d',
         renewalPackageId: '0xd5e5f74126e7934e35991643b0111c3361827fc0564c83fa810668837c6f0b0f',
         registryTableId: '0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106',
+        reverseRegistryTableId: '0xcafc893c3801416ffa4c262888eaa994e055d717d9b0819db3aef4ce35ab5829'
     }
 });
 ```

--- a/scripts/config/constants.ts
+++ b/scripts/config/constants.ts
@@ -21,6 +21,7 @@ export type PackageInfo = {
 	paymentsPackageId: string;
 	publisherId: string;
 	registryTableId: string;
+	reverseRegistryTableId: string;
 	subNamesPackageId: string;
 	tempSubdomainsProxyPackageId: string;
 	treasuryAddress?: string;

--- a/scripts/init/queries.ts
+++ b/scripts/init/queries.ts
@@ -4,17 +4,11 @@
 
 import { IotaClient } from '@iota/iota-sdk/client';
 
-export const queryRegistryTable = async (
+export const queryRegistryTables = async (
 	client: IotaClient,
 	iotaNames: string,
 	iotaNamesPackageId: string,
 ) => {
-	const allFields = await client.getDynamicFields({
-		parentId: iotaNames,
-	});
-
-	// just for testing..
-	console.log(allFields);
 	const table = await client.getDynamicFieldObject({
 		parentId: iotaNames,
 		name: {
@@ -25,12 +19,11 @@ export const queryRegistryTable = async (
 		},
 	});
 
-	console.log(table);
-	console.log(iotaNames);
-
 	if (table.data?.content?.dataType !== 'moveObject')
 		throw new Error(`Invalid data ${iotaNamesPackageId}`);
 
 	const data = table.data?.content.fields as Record<string, any>;
-	return data.value.fields.registry.fields.id.id;
+	let registryTableId = data.value.fields.registry.fields.id.id;
+	let reverseRegistryTableId = data.value.fields.reverse_registry.fields.id.id;
+	return { registryTableId, reverseRegistryTableId };
 };

--- a/scripts/init/setup.ts
+++ b/scripts/init/setup.ts
@@ -12,7 +12,7 @@ import {
 import { getActiveAddress, getClient, getCoinMetadataId, signAndExecute } from '../utils/utils';
 import { authorizeApp } from './authorization';
 import { Packages } from './packages';
-import { queryRegistryTable } from './queries';
+import { queryRegistryTables } from './queries';
 import { PackageInfo } from './types';
 
 export const setup = async (packageInfo: PackageInfo, network: string) => {
@@ -34,10 +34,13 @@ export const setup = async (packageInfo: PackageInfo, network: string) => {
 		paymentsPackageId: packageInfo.Payments.packageId,
 		publisherId: packageInfo.IotaNames.publisher,
 		registryTableId: '',
+		reverseRegistryTableId: '',
 		subNamesPackageId: packageInfo.Subdomains.packageId,
 		tempSubdomainsProxyPackageId: packageInfo.TempSubdomainProxy.packageId,
 	};
 	writePackageInfo(network, networkPackageInfo);
+
+	console.log('Setting up packages...');
 	const packages = Packages(network);
 
 	const txb = new Transaction();
@@ -87,16 +90,18 @@ export const setup = async (packageInfo: PackageInfo, network: string) => {
 	try {
 		txb.setGasBudget(1_000_000_000);
 
+		const client = getClient(network);
+		let digest = '';
 		while (retries < 3) {
-			console.log('Retrying setup...');
 			const res = await signAndExecute(txb, network);
-
-			await getClient(network).waitForTransaction({
-				digest: res.digest,
+			digest = res.digest;
+			await client.waitForTransaction({
+				digest,
 			});
 
 			if (res.effects?.status.status === 'success') break;
 			console.log(res);
+			console.log('Retrying setup...');
 			retries++;
 
 			if (retries === 3) {
@@ -105,22 +110,18 @@ export const setup = async (packageInfo: PackageInfo, network: string) => {
 			}
 		}
 
-		console.log('******* Packages set up successfully *******');
+		console.log(`******* Packages set up successfully in ${digest} *******`);
 
 		try {
-			// correct the sdk constants to also include the registryTableID
 			const constants = readPackageInfo(network);
 
-			console.log(constants);
-
-			// delay 3 seconds
-			await new Promise((resolve) => setTimeout(resolve, 3000));
-
-			constants.registryTableId = await queryRegistryTable(
-				getClient(network),
+			let { registryTableId, reverseRegistryTableId } = await queryRegistryTables(
+				client,
 				packageInfo.IotaNames.iotaNames,
 				packageInfo.IotaNames.packageId,
 			);
+			constants.registryTableId = registryTableId;
+			constants.reverseRegistryTableId = reverseRegistryTableId;
 
 			writePackageInfo(network, constants);
 		} catch (e) {

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -31,6 +31,7 @@ export const mainPackage: Config = {
 			},
 		},
 		registryTableId: '0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106',
+		reverseRegistryTableId: '0xcafc893c3801416ffa4c262888eaa994e055d717d9b0819db3aef4ce35ab5829',
 	},
 	testnet: {
 		packageId: '0x40eee27b014a872f5c3330dcd5329aa55c7fe0fcc6e70c6498852e2e3727172e',
@@ -49,5 +50,6 @@ export const mainPackage: Config = {
 			},
 		},
 		registryTableId: '0xb120c0d55432630fce61f7854795a3463deb6e3b443cc4ae72e1282073ff56e4',
+		reverseRegistryTableId: '0xcafc893c3801416ffa4c262888eaa994e055d717d9b0819db3aef4ce35ab5829',
 	},
 };

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -25,6 +25,7 @@ export interface PackageInfo {
 		packageId: string;
 	};
 	registryTableId?: string;
+	reverseRegistryTableId?: string;
 	coins: Record<string, CoinConfig>;
 }
 


### PR DESCRIPTION
Add reverseRegistryTableId to PackageInfo so one can read it from there later
Also cleaned the publish output a bit since it contained logs that were there only for testing

Fixes https://github.com/iotaledger/iota-names/issues/95

Tested in a localnet with `export NETWORK=localnet && pnpm ts-node init/init.ts`