### PR TITLE
fix(scripts): correctly set adminAddress

### DIFF
--- a/scripts/init/setup.ts
+++ b/scripts/init/setup.ts
@@ -9,7 +9,7 @@ import {
 	readPackageInfo,
 	writePackageInfo,
 } from '../config/constants';
-import { getClient, getCoinMetadataId, signAndExecute } from '../utils/utils';
+import { getActiveAddress, getClient, getCoinMetadataId, signAndExecute } from '../utils/utils';
 import { authorizeApp } from './authorization';
 import { Packages } from './packages';
 import { queryRegistryTable } from './queries';
@@ -19,7 +19,7 @@ export const setup = async (packageInfo: PackageInfo, network: string) => {
 	const iotaCoinType =
 		'0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA';
 	const networkPackageInfo: NetworkPackageInfo = {
-		adminAddress: packageInfo.IotaNames.publisher,
+		adminAddress: getActiveAddress(),
 		adminCap: packageInfo.IotaNames.adminCap,
 		iotaNames: packageInfo.IotaNames.iotaNames,
 		packageId: packageInfo.IotaNames.packageId,


### PR DESCRIPTION
Correctly set the adminAddress, before it was set to the Published object ID.

Fixes https://github.com/iotaledger/iota-names/issues/102

Tested with `pnpm ts-node init/init.ts`, now the address is set correct