### PR TITLE
feat(iota-names)!: remove IotaNames::balance

### DIFF
--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -97,7 +97,7 @@ fun init(otw: IOTA_NAMES, ctx: &mut TxContext) {
 // === Admin actions ===
 
 /// Withdraw from the IotaNames balance of a custom coin type.
-public fun withdraw_custom<T>(self: &mut IotaNames, _: &AdminCap, ctx: &mut TxContext): Coin<T> {
+public fun withdraw<T>(self: &mut IotaNames, _: &AdminCap, ctx: &mut TxContext): Coin<T> {
     let balance_key = BalanceKey<T> {};
     assert!(self.id.exists_(balance_key), ENoProfitsInCoinType);
 
@@ -137,7 +137,7 @@ public fun assert_app_is_authorized<App: drop>(self: &IotaNames) {
 // === Protected features ===
 
 /// Adds a balance of type `T` to the IotaNames protocol as an authorized app.
-public fun app_add_custom_balance<App: drop, T>(self: &mut IotaNames, _: App, balance: Balance<T>) {
+public fun app_add_balance<App: drop, T>(self: &mut IotaNames, _: App, balance: Balance<T>) {
     self.assert_app_is_authorized<App>();
     let key = BalanceKey<T> {};
     if (self.id.exists_(key)) {

--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -96,7 +96,7 @@ fun init(otw: IOTA_NAMES, ctx: &mut TxContext) {
 
 // === Admin actions ===
 
-/// Withdraw from the IotaNames balance of a custom coin type.
+/// Withdraw from the IotaNames balance of a provided coin type.
 public fun withdraw<T>(self: &mut IotaNames, _: &AdminCap, ctx: &mut TxContext): Coin<T> {
     let balance_key = BalanceKey<T> {};
     assert!(self.id.exists_(balance_key), ENoProfitsInCoinType);

--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -23,10 +23,9 @@
 /// the registry and the balance.
 module iota_names::iota_names;
 
-use iota::balance::{Self, Balance};
-use iota::coin::{Self, Coin};
+use iota::balance::Balance;
+use iota::coin::Coin;
 use iota::dynamic_field as df;
-use iota::iota::IOTA;
 
 use fun df::add as UID.add;
 use fun df::borrow as UID.borrow;
@@ -34,8 +33,6 @@ use fun df::borrow_mut as UID.borrow_mut;
 use fun df::exists_ as UID.exists_;
 use fun df::remove as UID.remove;
 
-#[error]
-const ENoProfits: vector<u8> = b"Trying to withdraw from an empty balance.";
 #[error]
 const EAppNotAuthorized: vector<u8> = b"The application is not authorized to access the feature.";
 #[error]
@@ -51,11 +48,10 @@ public struct AdminCap has key, store { id: UID }
 /// Dynamic fields:
 /// - `registry: RegistryKey<R> -> R`
 /// - `config: ConfigKey<C> -> C`
+/// - `balance: BalanceKey<T> -> Balance<T>`
+/// - `authorized_app: AppKey<App> -> bool`
 public struct IotaNames has key {
     id: UID,
-    /// The total balance of the IotaNames. Can be added to by authorized apps.
-    /// Can be withdrawn only by the application Admin.
-    balance: Balance<IOTA>,
 }
 
 /// The one-time-witness used to claim Publisher object.
@@ -93,23 +89,12 @@ fun init(otw: IOTA_NAMES, ctx: &mut TxContext) {
 
     let iota_names = IotaNames {
         id: object::new(ctx),
-        balance: balance::zero(),
     };
 
     transfer::share_object(iota_names);
 }
 
 // === Admin actions ===
-
-/// Withdraw from the IotaNames balance directly and access the Coins within the
-/// same
-/// transaction. This is useful for the admin to withdraw funds from the IotaNames
-/// and then send them somewhere specific or keep at the address.
-public fun withdraw(_: &AdminCap, self: &mut IotaNames, ctx: &mut TxContext): Coin<IOTA> {
-    let amount = self.balance.value();
-    assert!(amount > 0, ENoProfits);
-    coin::take(&mut self.balance, amount, ctx)
-}
 
 /// Withdraw from the IotaNames balance of a custom coin type.
 public fun withdraw_custom<T>(self: &mut IotaNames, _: &AdminCap, ctx: &mut TxContext): Coin<T> {
@@ -150,12 +135,6 @@ public fun assert_app_is_authorized<App: drop>(self: &IotaNames) {
 }
 
 // === Protected features ===
-
-/// Adds balance to the IotaNames.
-public fun app_add_balance<App: drop>(_: App, self: &mut IotaNames, balance: Balance<IOTA>) {
-    self.assert_app_is_authorized<App>();
-    self.balance.join(balance);
-}
 
 /// Adds a balance of type `T` to the IotaNames protocol as an authorized app.
 public fun app_add_custom_balance<App: drop, T>(self: &mut IotaNames, _: App, balance: Balance<T>) {
@@ -231,7 +210,7 @@ const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 #[test_only]
 public fun new_for_testing(ctx: &mut TxContext): (IotaNames, AdminCap) {
-    (IotaNames { id: object::new(ctx), balance: balance::zero() }, AdminCap { id: object::new(ctx) })
+    (IotaNames { id: object::new(ctx) }, AdminCap { id: object::new(ctx) })
 }
 
 #[test_only]
@@ -240,7 +219,6 @@ public fun init_for_testing(ctx: &mut TxContext): IotaNames {
     let admin_cap = AdminCap { id: object::new(ctx) };
     let mut iota_names = IotaNames {
         id: object::new(ctx),
-        balance: balance::zero(),
     };
 
     admin_cap.add_config(&mut iota_names, core_config::default());
@@ -296,7 +274,3 @@ public fun authorize_app_for_testing<App: drop>(self: &mut IotaNames) {
     df::add(&mut self.id, AppKey<App> {}, true)
 }
 
-#[test_only]
-public fun total_balance(self: &IotaNames): u64 {
-    self.balance.value()
-}

--- a/packages/iota-names/sources/iota_names.move
+++ b/packages/iota-names/sources/iota_names.move
@@ -101,7 +101,9 @@ public fun withdraw<T>(self: &mut IotaNames, _: &AdminCap, ctx: &mut TxContext):
     let balance_key = BalanceKey<T> {};
     assert!(self.id.exists_(balance_key), ENoProfitsInCoinType);
 
-    self.id.borrow_mut<_, Balance<T>>(balance_key).withdraw_all().into_coin(ctx)
+    let balance = self.id.borrow_mut<_, Balance<T>>(balance_key);
+    assert!(balance.value() > 0, ENoProfitsInCoinType);
+    balance.withdraw_all().into_coin(ctx)
 }
 
 // === App Auth ===

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -113,7 +113,7 @@ public fun finalize_payment<A: drop, T>(
 ): Receipt {
     iota_names.assert_app_is_authorized<A>();
     event::emit(intent.to_event<A, T>(coin.value()));
-    iota_names.app_add_custom_balance(app, coin.into_balance());
+    iota_names.app_add_balance(app, coin.into_balance());
 
     match (intent) {
         PaymentIntent::Registration(data) => {

--- a/packages/iota-names/tests/test_utils/register.move
+++ b/packages/iota-names/tests/test_utils/register.move
@@ -52,7 +52,7 @@ public fun register<T>(
     let price = config.calculate_base_price(label.length()) * (no_years as u64);
     assert!(payment.value() == price, EIncorrectAmount);
 
-    iota_names.app_add_custom_balance<_, T>(Register {}, payment.into_balance());
+    iota_names.app_add_balance<_, T>(Register {}, payment.into_balance());
     let registry = iota_names::app_registry_mut<Register, Registry>(
         Register {},
         iota_names,

--- a/packages/iota-names/tests/unit/iota_names_tests.move
+++ b/packages/iota-names/tests/unit/iota_names_tests.move
@@ -53,79 +53,11 @@ fun registry_management() {
 public struct TestApp has drop {}
 
 #[test, expected_failure(abort_code = ::iota_names::iota_names::EAppNotAuthorized)]
-/// Only authorized applications can add balance to IotaNames.
-fun app_add_to_balance_fail() {
-    let mut ctx = tx_context::dummy();
-    let (mut iota_names, _cap) = iota_names::new_for_testing(&mut ctx);
-    iota_names::app_add_balance(TestApp {}, &mut iota_names, balance::zero());
-    abort 1337
-}
-
-#[test, expected_failure(abort_code = ::iota_names::iota_names::EAppNotAuthorized)]
 /// Only authorized applications can access the registry mut.
 fun app_registry_mut_fail() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, _cap) = iota_names::new_for_testing(&mut ctx);
     iota_names::app_registry_mut<TestApp, TestRegistry>(TestApp {}, &mut iota_names);
-    abort 1337
-}
-
-#[test]
-/// 1. Authorize TestApp;
-/// 2. Adds balance to IotaNames, access registry mut.
-fun authorize_and_access() {
-    let mut ctx = tx_context::dummy();
-    let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
-    iota_names::add_registry(&cap, &mut iota_names, TestRegistry { counter: 1 });
-
-    // authorize and check right away
-    iota_names::authorize_app<TestApp>(&cap, &mut iota_names);
-    assert!(iota_names.is_app_authorized<TestApp>(), 0);
-    iota_names.assert_app_is_authorized<TestApp>();
-
-    // add balance and read registry
-    iota_names::app_add_balance(TestApp {}, &mut iota_names, balance::zero());
-    let registry = iota_names::app_registry_mut<TestApp, TestRegistry>(
-        TestApp {},
-        &mut iota_names,
-    );
-    registry.counter = 2;
-
-    // now read the registry again
-    assert_eq(iota_names.registry<TestRegistry>().counter, 2);
-
-    // deauthorize application
-    iota_names::deauthorize_app<TestApp>(&cap, &mut iota_names);
-    assert!(!iota_names.is_app_authorized<TestApp>(), 0);
-
-    wrapup(iota_names, cap);
-}
-
-#[test]
-/// 1. Authorize TestApp and add to balance;
-/// 2. Admin withdraws the balance.
-fun balance_and_withdraw() {
-    let mut ctx = tx_context::dummy();
-    let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
-    iota_names::authorize_app<TestApp>(&cap, &mut iota_names);
-
-    let paid = balance::create_for_testing<IOTA>(1000);
-    iota_names::app_add_balance(TestApp {}, &mut iota_names, paid);
-
-    let withdrawn = iota_names::withdraw(&cap, &mut iota_names, &mut ctx);
-    assert_eq(coin::burn_for_testing(withdrawn), 1000);
-
-    wrapup(iota_names, cap);
-}
-
-#[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfits)]
-/// 1. Authorize TestApp and add to balance;
-/// 2. Admin tries to withdraw an empty balance.
-fun balance_and_withdraw_fail_no_profits() {
-    let mut ctx = tx_context::dummy();
-    let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
-    let _withdrawn = iota_names::withdraw(&cap, &mut iota_names, &mut ctx);
-
     abort 1337
 }
 

--- a/packages/iota-names/tests/unit/iota_names_tests.move
+++ b/packages/iota-names/tests/unit/iota_names_tests.move
@@ -53,6 +53,15 @@ fun registry_management() {
 public struct TestApp has drop {}
 
 #[test, expected_failure(abort_code = ::iota_names::iota_names::EAppNotAuthorized)]
+/// Only authorized applications can add balance to IotaNames.
+fun app_add_to_balance_fail() {
+    let mut ctx = tx_context::dummy();
+    let (mut iota_names, _cap) = iota_names::new_for_testing(&mut ctx);
+    iota_names.app_add_balance<TestApp, IOTA>(TestApp {}, balance::zero());
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::iota_names::iota_names::EAppNotAuthorized)]
 /// Only authorized applications can access the registry mut.
 fun app_registry_mut_fail() {
     let mut ctx = tx_context::dummy();

--- a/packages/iota-names/tests/unit/iota_names_tests.move
+++ b/packages/iota-names/tests/unit/iota_names_tests.move
@@ -62,15 +62,15 @@ fun app_registry_mut_fail() {
 }
 
 #[test]
-fun balance_and_withdraw_v2() {
+fun balance_and_withdraw() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
     iota_names::authorize_app<TestApp>(&cap, &mut iota_names);
 
     let paid = balance::create_for_testing<IOTA>(1000);
-    iota_names.app_add_custom_balance<TestApp, IOTA>(TestApp {}, paid);
+    iota_names.app_add_balance<TestApp, IOTA>(TestApp {}, paid);
 
-    let withdrawn = iota_names.withdraw_custom<IOTA>(&cap, &mut ctx);
+    let withdrawn = iota_names.withdraw<IOTA>(&cap, &mut ctx);
     assert_eq(coin::burn_for_testing(withdrawn), 1000);
 
     wrapup(iota_names, cap);
@@ -79,14 +79,14 @@ fun balance_and_withdraw_v2() {
 #[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfitsInCoinType)]
 /// 1. Authorize TestApp and add to balance;
 /// 2. Admin tries to withdraw an empty balance.
-fun balance_and_withdraw_fail_no_profits_in_type_v2() {
+fun balance_and_withdraw_fail_no_profits_in_type() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
     iota_names::authorize_app<TestApp>(&cap, &mut iota_names);
 
     let paid = balance::create_for_testing<IOTA>(1000);
-    iota_names.app_add_custom_balance<TestApp, IOTA>(TestApp {}, paid);
-    let _withdrawn = iota_names.withdraw_custom<USDC>(&cap, &mut ctx);
+    iota_names.app_add_balance<TestApp, IOTA>(TestApp {}, paid);
+    let _withdrawn = iota_names.withdraw<USDC>(&cap, &mut ctx);
 
     abort 1337
 }
@@ -94,10 +94,10 @@ fun balance_and_withdraw_fail_no_profits_in_type_v2() {
 #[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfitsInCoinType)]
 /// 1. Authorize TestApp and add to balance;
 /// 2. Admin tries to withdraw an empty balance.
-fun balance_and_withdraw_fail_no_profits_v2() {
+fun balance_and_withdraw_fail_no_profits() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
-    let _withdrawn = iota_names.withdraw_custom<IOTA>(&cap, &mut ctx);
+    let _withdrawn = iota_names.withdraw<IOTA>(&cap, &mut ctx);
 
     abort 1337
 }

--- a/packages/iota-names/tests/unit/iota_names_tests.move
+++ b/packages/iota-names/tests/unit/iota_names_tests.move
@@ -78,7 +78,7 @@ fun balance_and_withdraw() {
 
 #[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfitsInCoinType)]
 /// 1. Authorize TestApp and add to balance;
-/// 2. Admin tries to withdraw an empty balance.
+/// 2. Admin tries to withdraw an empty balance (other coin).
 fun balance_and_withdraw_fail_no_profits_in_type() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
@@ -92,11 +92,28 @@ fun balance_and_withdraw_fail_no_profits_in_type() {
 }
 
 #[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfitsInCoinType)]
-/// 1. Authorize TestApp and add to balance;
-/// 2. Admin tries to withdraw an empty balance.
+/// Admin tries to withdraw an empty balance.
 fun balance_and_withdraw_fail_no_profits() {
     let mut ctx = tx_context::dummy();
     let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
+    let _withdrawn = iota_names.withdraw<IOTA>(&cap, &mut ctx);
+
+    abort 1337
+}
+
+
+#[test, expected_failure(abort_code = ::iota_names::iota_names::ENoProfitsInCoinType)]
+/// 1. Authorize TestApp and add 0 balance;
+/// 2. Admin tries to withdraw from 0 balance.
+fun balance_and_withdraw_fail_no_profits2() {
+    let mut ctx = tx_context::dummy();
+    let (mut iota_names, cap) = iota_names::new_for_testing(&mut ctx);
+    iota_names::authorize_app<TestApp>(&cap, &mut iota_names);
+
+    // Add 0 balance
+    let paid = balance::create_for_testing<IOTA>(0);
+    iota_names.app_add_balance<TestApp, IOTA>(TestApp {}, paid);
+
     let _withdrawn = iota_names.withdraw<IOTA>(&cap, &mut ctx);
 
     abort 1337

--- a/scripts/transactions/funds-to-treasury.ts
+++ b/scripts/transactions/funds-to-treasury.ts
@@ -33,7 +33,7 @@ export async function profitsToTreasury(
 	treasuryAddress: string,
 ) {
 	const generalProfits = txb.moveCall({
-		target: `${packageInfo.packageId}::iota_names::withdraw_custom`,
+		target: `${packageInfo.packageId}::iota_names::withdraw`,
 		arguments: [txb.object(packageInfo.iotaNames), txb.object(packageInfo.adminCap)],
 		typeArguments: ['0x2::iota::IOTA'],
 	});


### PR DESCRIPTION
Remove the IotaNames::balance field as balances are stored as dynamic field

Fixes https://github.com/iotaledger/iota-names/issues/113

Should we remove the `_custom` from `app_add_custom_balance`, `withdraw_custom` now?