### PR TITLE
chore: Use `#[test_only]` in test modules

### DIFF
--- a/.github/workflows/move_test.yaml
+++ b/.github/workflows/move_test.yaml
@@ -34,10 +34,9 @@ jobs:
         run: |
           for dir in packages/*; do
             dir_name=$(basename "$dir")
-              echo "Running iota move build in $dir"
-              iota move build --path "$dir" --lint --warnings-are-errors --dev
+            echo "Running iota move build in $dir"
+            iota move build --path "$dir" --lint --warnings-are-errors --dev
 
-              echo "Running iota move test in $dir"
-              iota move test --path "$dir"
-            fi
+            echo "Running iota move test in $dir"
+            iota move test --path "$dir"
           done

--- a/.github/workflows/move_test.yaml
+++ b/.github/workflows/move_test.yaml
@@ -32,11 +32,12 @@ jobs:
 
       - name: Run move tests in all package subdirectories, with exclusions
         run: |
-          excluded_dirs=(day_one governance) # Define excluded directories as an array
           for dir in packages/*; do
             dir_name=$(basename "$dir")
-            if [[ ! " ${excluded_dirs[*]} " =~ (^|[[:space:]])${dir_name}($|[[:space:]]) ]] && [ -d "$dir" ]; then
+              echo "Running iota move build in $dir"
+              iota move build --path "$dir" --lint --warnings-are-errors --dev
+              
               echo "Running iota move test in $dir"
-              iota move test --path "$dir" --lint --warnings-are-errors
+              iota move test --path "$dir"
             fi
           done

--- a/.github/workflows/move_test.yaml
+++ b/.github/workflows/move_test.yaml
@@ -36,7 +36,7 @@ jobs:
             dir_name=$(basename "$dir")
               echo "Running iota move build in $dir"
               iota move build --path "$dir" --lint --warnings-are-errors --dev
-              
+
               echo "Running iota move test in $dir"
               iota move test --path "$dir"
             fi

--- a/packages/deny-list/tests/deny_list_tests.move
+++ b/packages/deny-list/tests/deny_list_tests.move
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[test_only]
 #[allow(lint(abort_without_constant))]
 module deny_list::deny_list_tests {
     use std::string::{utf8, String};

--- a/packages/iota-names/tests/payments/pricing_tests.move
+++ b/packages/iota-names/tests/payments/pricing_tests.move
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[test_only]
 module iota_names::pricing_config_tests;
 
 use iota_names::pricing_config;

--- a/packages/iota-names/tests/unit/core_config_tests.move
+++ b/packages/iota-names/tests/unit/core_config_tests.move
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[test_only]
 module iota_names::core_config_tests;
 
 use iota::test_utils::assert_eq;


### PR DESCRIPTION
### Description

Use the `#[test_only]` tag for test modules to avoid build errors in `--dev` mode.