### PR TITLE
chore: increase auction test coverage

### DIFF
--- a/packages/auction/sources/auction.move
+++ b/packages/auction/sources/auction.move
@@ -43,8 +43,8 @@ const EAuctionStarted: vector<u8> =
 const EAuctionNotStarted: vector<u8> =
     b"Placing a bid in a not started auction.";
 #[error]
-const EAuctionNotEndedYet: vector<u8> =
-    b"The auction has not ended yet.";
+const EAuctionNotEnded: vector<u8> =
+    b"The auction has not ended.";
 #[error]
 const EAuctionEnded: vector<u8> =
     b"The auction ended.";
@@ -234,7 +234,7 @@ public fun claim(
     } = self.auctions.remove(domain);
 
     // Ensure that the auction is over
-    assert!(clock.timestamp_ms() > end_timestamp_ms, EAuctionNotEndedYet);
+    assert!(clock.timestamp_ms() > end_timestamp_ms, EAuctionNotEnded);
 
     // Ensure the sender is the winner
     assert!(ctx.sender() == winner, ENotWinner);
@@ -292,7 +292,7 @@ public fun collect_winning_auction_fund(
     let domain = domain::new(domain_name);
     let auction = &mut self.auctions[domain];
     // Ensure that the auction is over
-    assert!(clock.timestamp_ms() > auction.end_timestamp_ms, EAuctionNotEndedYet);
+    assert!(clock.timestamp_ms() > auction.end_timestamp_ms, EAuctionNotEnded);
 
     let amount = auction.current_bid.value();
     self.balance.join(auction.current_bid.split(amount, ctx).into_balance());
@@ -344,7 +344,7 @@ fun admin_finalize_auction_internal(
     } = self.auctions.remove(domain);
 
     // Ensure that the auction is over
-    assert!(clock.timestamp_ms() > end_timestamp_ms, EAuctionNotEndedYet);
+    assert!(clock.timestamp_ms() > end_timestamp_ms, EAuctionNotEnded);
 
     event::emit(AuctionFinalizedEvent {
         domain,

--- a/packages/auction/sources/auction.move
+++ b/packages/auction/sources/auction.move
@@ -428,11 +428,7 @@ public struct AuctionExtendedEvent has copy, drop {
 
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext) {
-    iota::transfer::share_object(AuctionHouse {
-        id: object::new(ctx),
-        balance: balance::zero(),
-        auctions: linked_table::new(ctx),
-    });
+    init(ctx)
 }
 
 #[test_only]

--- a/packages/auction/tests/auction_tests.move
+++ b/packages/auction/tests/auction_tests.move
@@ -299,7 +299,9 @@ public fun normal_auction_flow(scenario: &mut Scenario) {
 fun test_normal_auction_flow() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     normal_auction_flow(scenario);
+    
     scenario_val.end();
 }
 
@@ -307,6 +309,7 @@ fun test_normal_auction_flow() {
 fun test_claim_aborts_if_winner_claims_twice() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -335,6 +338,7 @@ fun test_claim_aborts_if_winner_claims_twice() {
         AUCTION_BIDDING_PERIOD_MS + 1,
     );
     nft.burn_for_testing();
+    
     scenario_val.end();
 }
 
@@ -342,6 +346,7 @@ fun test_claim_aborts_if_winner_claims_twice() {
 fun test_winner_can_place_bid() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -370,6 +375,7 @@ fun test_winner_can_place_bid() {
 fun test_place_bid_aborts_if_value_is_too_low() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -391,6 +397,7 @@ fun test_place_bid_aborts_if_value_is_too_low() {
 fun test_non_winner_cannot_claim() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -412,6 +419,7 @@ fun test_non_winner_cannot_claim() {
         AUCTION_BIDDING_PERIOD_MS + 1,
     );
     nft.burn_for_testing();
+    
     scenario_val.end();
 }
 
@@ -419,6 +427,7 @@ fun test_non_winner_cannot_claim() {
 fun test_admin_try_finalize_auction() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -477,6 +486,7 @@ fun test_admin_try_finalize_auction() {
 fun test_admin_try_finalize_auction_2_auctions() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -516,10 +526,11 @@ fun test_admin_try_finalize_auction_2_auctions() {
     scenario_val.end();
 }
 
-#[test, expected_failure(abort_code = auction::EAuctionNotEndedYet)]
+#[test, expected_failure(abort_code = auction::EAuctionNotEnded)]
 fun test_admin_try_finalize_auction_too_early() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -528,6 +539,7 @@ fun test_admin_try_finalize_auction_too_early() {
     );
 
     admin_try_finalize_auction_util(scenario, utf8(FIRST_DOMAIN_NAME), 0);
+    
     scenario_val.end();
 }
 
@@ -535,6 +547,7 @@ fun test_admin_try_finalize_auction_too_early() {
 fun test_admin_try_finalize_auctions_too_early() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -551,6 +564,7 @@ fun test_admin_try_finalize_auctions_too_early() {
 fun test_place_bid_aborts_if_too_late() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -564,6 +578,7 @@ fun test_place_bid_aborts_if_too_late() {
         1210 * NANOS_PER_IOTA,
         AUCTION_BIDDING_PERIOD_MS + 1,
     );
+    
     scenario_val.end();
 }
 
@@ -572,7 +587,9 @@ fun test_admin_withdraw_funds_aborts_if_no_profits() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
     let funds = admin_withdraw_funds_util(scenario);
+    
     coin::burn_for_testing(funds);
+    
     scenario_val.end();
 }
 
@@ -580,12 +597,14 @@ fun test_admin_withdraw_funds_aborts_if_no_profits() {
 fun test_start_auction_aborts_with_wrong_tld() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"test.move"),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -593,12 +612,14 @@ fun test_start_auction_aborts_with_wrong_tld() {
 fun test_start_auction_aborts_if_domain_name_too_short() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"tt.iota"),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -606,6 +627,7 @@ fun test_start_auction_aborts_if_domain_name_too_short() {
 fun test_start_auction_aborts_if_domain_name_too_long() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -614,6 +636,7 @@ fun test_start_auction_aborts_if_domain_name_too_long() {
         ),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -621,12 +644,14 @@ fun test_start_auction_aborts_if_domain_name_too_long() {
 fun test_start_auction_aborts_if_domain_name_starts_with_dash() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"-test.iota"),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -634,12 +659,14 @@ fun test_start_auction_aborts_if_domain_name_starts_with_dash() {
 fun test_start_auction_aborts_if_domain_name_ends_with_dash() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"test-.iota"),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -647,12 +674,14 @@ fun test_start_auction_aborts_if_domain_name_ends_with_dash() {
 fun test_start_auction_aborts_if_domain_name_contains_uppercase_characters() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"ttABC.iota"),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -660,6 +689,7 @@ fun test_start_auction_aborts_if_domain_name_contains_uppercase_characters() {
 fun test_place_bid_aborts_if_auction_not_started() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     place_bid_util(
         scenario,
         SECOND_ADDRESS,
@@ -667,6 +697,7 @@ fun test_place_bid_aborts_if_auction_not_started() {
         1210 * NANOS_PER_IOTA,
         0,
     );
+    
     scenario_val.end();
 }
 
@@ -674,12 +705,14 @@ fun test_place_bid_aborts_if_auction_not_started() {
 fun test_start_auction_aborts_if_not_enough_fee() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
         utf8(b"test.iota"),
         10 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -687,6 +720,7 @@ fun test_start_auction_aborts_if_not_enough_fee() {
 fun test_admin_collect_fund() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -731,10 +765,11 @@ fun test_admin_collect_fund() {
     scenario_val.end();
 }
 
-#[test, expected_failure(abort_code = auction::EAuctionNotEndedYet)]
+#[test, expected_failure(abort_code = auction::EAuctionNotEnded)]
 fun test_admin_collect_fund_aborts_if_too_early() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -742,6 +777,7 @@ fun test_admin_collect_fund_aborts_if_too_early() {
         1200 * NANOS_PER_IOTA,
     );
     admin_collect_fund_util(scenario, utf8(FIRST_DOMAIN_NAME), 0);
+    
     scenario_val.end();
 }
 
@@ -749,6 +785,7 @@ fun test_admin_collect_fund_aborts_if_too_early() {
 fun test_start_auction_and_place_bid_aborts_if_auction_is_deauthorized() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     deauthorize_app_util(scenario);
     start_auction_and_place_bid_util(
         scenario,
@@ -756,6 +793,7 @@ fun test_start_auction_and_place_bid_aborts_if_auction_is_deauthorized() {
         utf8(FIRST_DOMAIN_NAME),
         1200 * NANOS_PER_IOTA,
     );
+    
     scenario_val.end();
 }
 
@@ -763,6 +801,7 @@ fun test_start_auction_and_place_bid_aborts_if_auction_is_deauthorized() {
 fun test_place_bid_and_claim_and_withdraw_works_even_if_auction_is_deauthorized() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -813,6 +852,7 @@ fun test_place_bid_and_claim_and_withdraw_works_even_if_auction_is_deauthorized(
 fun test_admin_try_finalize_auction_works_even_if_auction_is_deauthorized() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -872,6 +912,7 @@ fun test_admin_try_finalize_auction_works_even_if_auction_is_deauthorized() {
 fun test_admin_collect_fund_even_if_auction_is_deauthorized() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -921,6 +962,7 @@ fun test_admin_collect_fund_even_if_auction_is_deauthorized() {
 fun test_overbid_less_than_1_IOTA() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -934,6 +976,7 @@ fun test_overbid_less_than_1_IOTA() {
         100 * NANOS_PER_IOTA + 100,
         0,
     );
+    
     scenario_val.end();
 }
 
@@ -941,6 +984,7 @@ fun test_overbid_less_than_1_IOTA() {
 fun test_overbid_of_1_IOTA() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -954,6 +998,7 @@ fun test_overbid_of_1_IOTA() {
         101 * NANOS_PER_IOTA,
         0,
     );
+    
     scenario_val.end();
 }
 
@@ -961,6 +1006,7 @@ fun test_overbid_of_1_IOTA() {
 fun test_overbid_of_1_IOTA_and_1_NANO() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
+    
     start_auction_and_place_bid_util(
         scenario,
         FIRST_ADDRESS,
@@ -974,5 +1020,50 @@ fun test_overbid_of_1_IOTA_and_1_NANO() {
         101 * NANOS_PER_IOTA + 1,
         0,
     );
+    
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = auction::EAuctionStarted)]
+fun test_auction_started() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    
+    start_auction_and_place_bid_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        100 * NANOS_PER_IOTA,
+    );
+    start_auction_and_place_bid_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        100 * NANOS_PER_IOTA,
+    );
+
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = auction::EAuctionNotEnded)]
+fun test_auction_not_ended() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    start_auction_and_place_bid_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        100 * NANOS_PER_IOTA,
+    );
+    let nft = claim_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        AUCTION_BIDDING_PERIOD_MS,
+    );
+
+    nft.burn_for_testing();
+
     scenario_val.end();
 }

--- a/packages/auction/tests/auction_tests.move
+++ b/packages/auction/tests/auction_tests.move
@@ -223,23 +223,23 @@ fun assert_balance(scenario: &mut Scenario, amount: u64) {
 fun assert_auction(
     scenario: &mut Scenario,
     domain_name: String,
-    expected_start_ms: u64,
-    expected_end_ms: u64,
-    expected_winner: address,
-    expected_highest_amount: u64,
+    expected_start_ms: Option<u64>,
+    expected_end_ms: Option<u64>,
+    expected_winner: Option<address>,
+    expected_highest_amount: Option<u64>,
 ) {
     scenario.next_tx(IOTA_NAMES_ADDRESS);
     let auction_house = scenario.take_shared<AuctionHouse>();
     let (
-        mut start_ms,
-        mut end_ms,
-        mut winner,
-        mut highest_amount,
+        start_ms,
+        end_ms,
+        winner,
+        highest_amount,
     ) = auction_house.get_auction_metadata(domain_name);
-    assert!(option::extract(&mut start_ms) == expected_start_ms, 0);
-    assert!(option::extract(&mut end_ms) == expected_end_ms, 0);
-    assert!(option::extract(&mut winner) == expected_winner, 0);
-    assert!(option::extract(&mut highest_amount) == expected_highest_amount, 0);
+    assert!(start_ms == expected_start_ms, 0);
+    assert!(end_ms == expected_end_ms, 0);
+    assert!(winner == expected_winner, 0);
+    assert!(highest_amount == expected_highest_amount, 0);
     test_scenario::return_shared(auction_house);
 }
 
@@ -253,10 +253,10 @@ public fun normal_auction_flow(scenario: &mut Scenario) {
     assert_auction(
         scenario,
         utf8(FIRST_DOMAIN_NAME),
-        0,
-        AUCTION_BIDDING_PERIOD_MS,
-        FIRST_ADDRESS,
-        1200 * NANOS_PER_IOTA,
+        option::some(0),
+        option::some(AUCTION_BIDDING_PERIOD_MS),
+        option::some(FIRST_ADDRESS),
+        option::some(1200 * NANOS_PER_IOTA),
     );
     place_bid_util(
         scenario,
@@ -268,10 +268,10 @@ public fun normal_auction_flow(scenario: &mut Scenario) {
     assert_auction(
         scenario,
         utf8(FIRST_DOMAIN_NAME),
-        0,
-        AUCTION_BIDDING_PERIOD_MS,
-        SECOND_ADDRESS,
-        1210 * NANOS_PER_IOTA,
+        option::some(0),
+        option::some(AUCTION_BIDDING_PERIOD_MS),
+        option::some(SECOND_ADDRESS),
+        option::some(1210 * NANOS_PER_IOTA),
     );
 
     let nft = claim_util(
@@ -819,10 +819,10 @@ fun test_place_bid_and_claim_and_withdraw_works_even_if_auction_is_deauthorized(
     assert_auction(
         scenario,
         utf8(FIRST_DOMAIN_NAME),
-        0,
-        AUCTION_BIDDING_PERIOD_MS,
-        SECOND_ADDRESS,
-        1210 * NANOS_PER_IOTA,
+        option::some(0),
+        option::some(AUCTION_BIDDING_PERIOD_MS),
+        option::some(SECOND_ADDRESS),
+        option::some(1210 * NANOS_PER_IOTA),
     );
 
     let nft = claim_util(
@@ -1064,6 +1064,29 @@ fun test_auction_not_ended() {
     );
 
     nft.burn_for_testing();
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_auction_metadata_none() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    
+    start_auction_and_place_bid_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        1200 * NANOS_PER_IOTA,
+    );
+    assert_auction(
+        scenario,
+        utf8(SECOND_DOMAIN_NAME),
+        option::none(),
+        option::none(),
+        option::none(),
+        option::none()
+    );
 
     scenario_val.end();
 }

--- a/packages/auction/tests/auction_tests.move
+++ b/packages/auction/tests/auction_tests.move
@@ -1090,3 +1090,26 @@ fun test_auction_metadata_none() {
 
     scenario_val.end();
 }
+
+#[test]
+fun test_admin_zero_operations() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    
+    start_auction_and_place_bid_util(
+        scenario,
+        FIRST_ADDRESS,
+        utf8(FIRST_DOMAIN_NAME),
+        1200 * NANOS_PER_IOTA,
+    );
+
+    admin_try_finalize_auctions_util(
+        scenario,
+        0,
+        AUCTION_BIDDING_PERIOD_MS + 1,
+    );
+    
+    assert_balance(scenario, 0);
+
+    scenario_val.end();
+}

--- a/packages/auction/tests/auction_tests.move
+++ b/packages/auction/tests/auction_tests.move
@@ -1092,7 +1092,7 @@ fun test_auction_metadata_none() {
 }
 
 #[test]
-fun test_admin_zero_operations() {
+fun test_admin_try_finalize_auctions_zero_operations() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
     


### PR DESCRIPTION
From 92.10% to 100%

```
thibault@Mac ~/i/i/p/auction (auction-tests)> $IOTA move test --coverage
INCLUDING DEPENDENCY IotaNames
INCLUDING DEPENDENCY Iota
INCLUDING DEPENDENCY MoveStdlib
BUILDING auction

Running Move unit tests
[ PASS    ] iota_names::auction_tests::test_admin_collect_fund
[ PASS    ] iota_names::auction_tests::test_admin_collect_fund_aborts_if_too_early
[ PASS    ] iota_names::auction_tests::test_admin_collect_fund_even_if_auction_is_deauthorized
[ PASS    ] iota_names::auction_tests::test_admin_try_finalize_auction
[ PASS    ] iota_names::auction_tests::test_admin_try_finalize_auction_2_auctions
[ PASS    ] iota_names::auction_tests::test_admin_try_finalize_auction_too_early
[ PASS    ] iota_names::auction_tests::test_admin_try_finalize_auction_works_even_if_auction_is_deauthorized
[ PASS    ] iota_names::auction_tests::test_admin_try_finalize_auctions_too_early
[ PASS    ] iota_names::auction_tests::test_admin_withdraw_funds_aborts_if_no_profits
[ PASS    ] iota_names::auction_tests::test_admin_zero_operations
[ PASS    ] iota_names::auction_tests::test_auction_metadata_none
[ PASS    ] iota_names::auction_tests::test_auction_not_ended
[ PASS    ] iota_names::auction_tests::test_auction_started
[ PASS    ] iota_names::auction_tests::test_claim_aborts_if_winner_claims_twice
[ PASS    ] iota_names::auction_tests::test_non_winner_cannot_claim
[ PASS    ] iota_names::auction_tests::test_normal_auction_flow
[ PASS    ] iota_names::auction_tests::test_overbid_less_than_1_IOTA
[ PASS    ] iota_names::auction_tests::test_overbid_of_1_IOTA
[ PASS    ] iota_names::auction_tests::test_overbid_of_1_IOTA_and_1_NANO
[ PASS    ] iota_names::auction_tests::test_place_bid_aborts_if_auction_not_started
[ PASS    ] iota_names::auction_tests::test_place_bid_aborts_if_too_late
[ PASS    ] iota_names::auction_tests::test_place_bid_aborts_if_value_is_too_low
[ PASS    ] iota_names::auction_tests::test_place_bid_and_claim_and_withdraw_works_even_if_auction_is_deauthorized
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_domain_name_contains_uppercase_characters
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_domain_name_ends_with_dash
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_domain_name_starts_with_dash
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_domain_name_too_long
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_domain_name_too_short
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_if_not_enough_fee
[ PASS    ] iota_names::auction_tests::test_start_auction_aborts_with_wrong_tld
[ PASS    ] iota_names::auction_tests::test_start_auction_and_place_bid_aborts_if_auction_is_deauthorized
[ PASS    ] iota_names::auction_tests::test_winner_can_place_bid
Test result: OK. Total tests: 32; passed: 32; failed: 0
Total number of linter warnings suppressed: 1 (unique lints: 1)

thibault@Mac ~/i/i/p/auction (auction-tests)> $IOTA move coverage summary
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000000::auction
>>> % Module coverage: 100.00
+-------------------------+
| % Move Coverage: 100.00  |
+-------------------------+
```