### PR TITLE
chore: Ignore packages folder for top-level format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,4 @@ documentation/
 dprint.json
 pnpm-workspace.yaml
 .prettierrc
+packages


### PR DESCRIPTION
## Description

Ignores the packages folder at the top level for typescript prettier, as it will throw warnings.