### PR TITLE
feat: authorize subdomain proxy module

### DIFF
--- a/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
+++ b/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
@@ -18,6 +18,10 @@ use iota_names::subdomain_registration::SubdomainRegistration;
 use std::string::String;
 use subdomains::subdomains;
 
+/// Struct to authenticate this module in the IOTA-Names object, so it can be fetched dynamically by the CLI.
+/// It's not required for the functionality of this module.
+public struct SubdomainProxyAuth() has drop;
+
 public fun new(
     iota_names: &mut IotaNames,
     subdomain: &SubdomainRegistration,

--- a/scripts/init/packages.ts
+++ b/scripts/init/packages.ts
@@ -224,6 +224,7 @@ export const Packages = (network: string) => {
 			order: 3,
 			folder: 'temp-subdomain-proxy',
 			processPublish: (data: IotaTransactionBlockResponse) => parseCorePackageObjects(data),
+			authorizationType: (packageId: string) => `${packageId}::subdomain_proxy::SubdomainProxyAuth`,
 		},
 	};
 };


### PR DESCRIPTION
Add a new SubdomainProxyAuth so we can authorize the subdomain proxy module and later fetch this package dynamically in the CLI. This allows us to remove the hardcoded subdomain ID in the CLI.

Fixes the IOTA-Names part of https://github.com/iotaledger/iota-names/issues/135

Tested by publishing in a localnet
Getting the dynamic fields for the IOTA-Names object with `iota client dynamic-field 0xd4d293527a91db8becf0b27e055bc45f726bf3e874428e036c9fce1b8b49ab2a` shows this entry
`0xf755e1858f47b78611264a80e6752f8bbdf3014fb7d6ad469eeef59b3f915c3b::iota_names::AppKey<0xc958bd253a1b5cadfd3b094f49a91219a0456503fe76ff2d8e6faa157397fdc7::subdomain_proxy::SubdomainProxyAuth>`