### PR TITLE
fix(scripts): update admin address when a new owner was provided

### DIFF
--- a/scripts/init/init.ts
+++ b/scripts/init/init.ts
@@ -5,7 +5,7 @@
 import fs from 'fs';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
-import { readPackageInfo } from '../package-info/constants';
+import { readPackageInfo, writePackageInfo } from '../package-info/constants';
 import { parseCsvFile, reserveDomains } from '../reserved-names/reserve-names';
 import { getClient, getIotaNamesAdminObjects, signAndExecute } from '../utils/utils';
 import { publishPackages } from './publish';
@@ -75,6 +75,9 @@ export const init = async (
     const result = await signAndExecute(tx, network);
     await client.waitForTransaction({ digest: result.digest });
     console.log(`Transaction digest: ${result.digest}`);
+    // Update config with new owner
+    packageInfo.adminAddress = newOwner;
+    writePackageInfo(network, packageInfo);
 };
 
 init(network, newOwner, !!process.env.IS_CI_JOB);


### PR DESCRIPTION
Update the admin address in the config when a new owner was provided.
Tested in a localnet by running `ts-node init/init.ts localnet 0x1ca3c38e888493f869ac35346a2041d6cf87b0b935ebba14b35a08811d8a76e4`, the address in the config was updated to `0x1ca3c38e888493f869ac35346a2041d6cf87b0b935ebba14b35a08811d8a76e4` after the ownership was transferred

Fixes https://github.com/iotaledger/iota-names/issues/119