### PR TITLE
feat(iota-names): Split user data and metadata fields

### DIFF
--- a/packages/iota-names/sources/controller.move
+++ b/packages/iota-names/sources/controller.move
@@ -18,9 +18,6 @@ const CONTENT_HASH: vector<u8> = b"content_hash";
 
 use fun registry_mut as IotaNames.registry_mut;
 
-#[error]
-const EUnsupportedKey: vector<u8> = b"Unsupported key.";
-
 /// Authorization witness to call protected functions of `iota_names`.
 public struct ControllerAuth has drop {}
 
@@ -77,19 +74,17 @@ public fun set_user_data(
     clock: &Clock,
 ) {
     let registry = iota_names.registry_mut();
-    let mut data = *registry.get_data(nft.domain());
+    let mut data = *registry.get_user_data(nft.domain());
     let domain = nft.domain();
 
     registry.assert_nft_is_authorized(nft, clock);
-    let key_bytes = *key.as_bytes();
-    assert!(key_bytes == AVATAR || key_bytes == CONTENT_HASH, EUnsupportedKey);
 
     if (data.contains(&key)) {
         data.remove(&key);
     };
 
     data.insert(key, value);
-    registry.set_data(domain, data);
+    registry.set_user_data(domain, data);
 }
 
 /// User-facing function - remove a key from the name record's data.
@@ -100,7 +95,7 @@ public fun unset_user_data(
     clock: &Clock,
 ) {
     let registry = iota_names.registry_mut();
-    let mut data = *registry.get_data(nft.domain());
+    let mut data = *registry.get_user_data(nft.domain());
     let domain = nft.domain();
 
     registry.assert_nft_is_authorized(nft, clock);
@@ -109,7 +104,93 @@ public fun unset_user_data(
         data.remove(&key);
     };
 
-    registry.set_data(domain, data);
+    registry.set_user_data(domain, data);
+}
+
+/// Set the avatar metadata for the record
+public fun set_avatar(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    value: String,
+    clock: &Clock,
+) {
+    let registry = iota_names.registry_mut();
+    let mut data = *registry.get_metadata(nft.domain());
+    let domain = nft.domain();
+
+    registry.assert_nft_is_authorized(nft, clock);
+    let key = AVATAR.to_string();
+
+    if (data.contains(&key)) {
+        data.remove(&key);
+    };
+
+    data.insert(key, value);
+    registry.set_metadata(domain, data);
+}
+
+/// Set the content hash metadata for the record
+public fun set_content_hash(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    value: String,
+    clock: &Clock,
+) {
+    let registry = iota_names.registry_mut();
+    let mut data = *registry.get_metadata(nft.domain());
+    let domain = nft.domain();
+
+    registry.assert_nft_is_authorized(nft, clock);
+    let key = CONTENT_HASH.to_string();
+
+    if (data.contains(&key)) {
+        data.remove(&key);
+    };
+
+    data.insert(key, value);
+    registry.set_metadata(domain, data);
+}
+
+/// Remove the currently set avatar metadata
+public fun unset_avatar(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    clock: &Clock,
+) {
+    let registry = iota_names.registry_mut();
+    let mut data = *registry.get_metadata(nft.domain());
+    let domain = nft.domain();
+
+    registry.assert_nft_is_authorized(nft, clock);
+
+    let key = AVATAR.to_string();
+
+    if (data.contains(&key)) {
+        data.remove(&key);
+    };
+
+    registry.set_metadata(domain, data);
+}
+
+/// Remove the currently set content hash metadata
+public fun unset_content_hash(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    clock: &Clock,
+) {
+    let registry = iota_names.registry_mut();
+    let mut data = *registry.get_metadata(nft.domain());
+    let domain = nft.domain();
+
+    registry.assert_nft_is_authorized(nft, clock);
+
+    let key = CONTENT_HASH.to_string();
+
+    if (data.contains(&key)) {
+        data.remove(&key);
+    };
+
+    registry.set_metadata(domain, data);
 }
 
 public fun burn_expired(iota_names: &mut IotaNames, nft: IotaNamesRegistration, clock: &Clock) {

--- a/packages/iota-names/sources/name_record.move
+++ b/packages/iota-names/sources/name_record.move
@@ -24,8 +24,10 @@ public struct NameRecord has copy, drop, store {
     expiration_timestamp_ms: u64,
     /// The target address that this domain points to
     target_address: Option<address>,
-    /// Additional data which may be stored in a record
-    data: VecMap<String, String>,
+    /// Additional user data which may be stored in a record
+    user_data: VecMap<String, String>,
+    /// Predefined metadata for use by external services
+    metadata: VecMap<String, String>,
 }
 
 /// Create a new NameRecord.
@@ -34,7 +36,8 @@ public fun new(nft_id: ID, expiration_timestamp_ms: u64): NameRecord {
         nft_id,
         expiration_timestamp_ms,
         target_address: option::none(),
-        data: vec_map::empty(),
+        user_data: vec_map::empty(),
+        metadata: vec_map::empty(),
     }
 }
 
@@ -44,25 +47,23 @@ public fun new_leaf(parent_id: ID, target_address: Option<address>): NameRecord 
         nft_id: parent_id,
         expiration_timestamp_ms: constants::leaf_expiration_timestamp(),
         target_address,
-        data: vec_map::empty(),
+        user_data: vec_map::empty(),
+        metadata: vec_map::empty(),
     }
 }
 
 // === Setters ===
 
-/// Set data as a vec_map directly overriding the data set in the
-/// registration self. This simplifies the editing flow and gives
-/// the user and clients a fine-grained control over custom data.
-///
-/// Here's a meta example of how a PTB would look like:
-/// ```
-/// let record = moveCall('data', [domain_name]);
-/// moveCall('vec_map::insert', [record.data, key, value]);
-/// moveCall('vec_map::remove', [record.data, other_key]);
-/// moveCall('set_data', [domain_name, record.data]);
-/// ```
-public fun set_data(self: &mut NameRecord, data: VecMap<String, String>) {
-    self.data = data;
+/// Set user data as a vec_map directly overriding the data set in the
+/// registration.
+public fun set_user_data(self: &mut NameRecord, user_data: VecMap<String, String>) {
+    self.user_data = user_data;
+}
+
+/// Set metadata as a vec_map directly overriding the data set in the
+/// registration.
+public fun set_metadata(self: &mut NameRecord, metadata: VecMap<String, String>) {
+    self.metadata = metadata;
 }
 
 /// Set the `target_address` field of the `NameRecord`.
@@ -91,8 +92,11 @@ public fun is_leaf_record(self: &NameRecord): bool {
     self.expiration_timestamp_ms == constants::leaf_expiration_timestamp()
 }
 
-/// Read the `data` field from the `NameRecord`.
-public fun data(self: &NameRecord): &VecMap<String, String> { &self.data }
+/// Read the `user_data` field from the `NameRecord`.
+public fun user_data(self: &NameRecord): &VecMap<String, String> { &self.user_data }
+
+/// Read the `metadata` field from the `NameRecord`.
+public fun metadata(self: &NameRecord): &VecMap<String, String> { &self.metadata }
 
 /// Read the `target_address` field from the `NameRecord`.
 public fun target_address(self: &NameRecord): Option<address> {

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -244,13 +244,18 @@ public fun set_expiration_timestamp_ms(
     nft.set_expiration_timestamp_ms(expiration_timestamp_ms);
 }
 
-/// Update the `data` of the given `NameRecord` using a `IotaNamesRegistration`.
-/// Use with caution and validate(!!) that any system fields are not removed
-/// (accidently),
-/// when building authorized packages that can write the metadata field.
-public fun set_data(self: &mut Registry, domain: Domain, data: VecMap<String, String>) {
+/// Update the user data of the given `NameRecord` using a `IotaNamesRegistration`.
+public fun set_user_data(self: &mut Registry, domain: Domain, user_data: VecMap<String, String>) {
     let record = &mut self.registry[domain];
-    record.set_data(data);
+    record.set_user_data(user_data);
+}
+
+/// Update the metadata of the given `NameRecord` using a `IotaNamesRegistration`.
+/// Use with caution and validate(!!) that any system fields are not removed
+/// when building authorized packages that can write the metadata field.
+public fun set_metadata(self: &mut Registry, domain: Domain, metadata: VecMap<String, String>) {
+    let record = &mut self.registry[domain];
+    record.set_metadata(metadata);
 }
 
 // === Reads ===
@@ -292,10 +297,16 @@ public fun assert_nft_is_authorized(self: &Registry, nft: &IotaNamesRegistration
     assert!(!nft.has_expired(clock), ENftExpired);
 }
 
-/// Returns the `data` associated with the given `Domain`.
-public fun get_data(self: &Registry, domain: Domain): &VecMap<String, String> {
+/// Returns the user data associated with the given `Domain`.
+public fun get_user_data(self: &Registry, domain: Domain): &VecMap<String, String> {
     let record = &self.registry[domain];
-    record.data()
+    record.user_data()
+}
+
+/// Returns the metadata associated with the given `Domain`.
+public fun get_metadata(self: &Registry, domain: Domain): &VecMap<String, String> {
+    let record = &self.registry[domain];
+    record.metadata()
 }
 
 // === Private Functions ===

--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -26,10 +26,15 @@ use std::string::{utf8, String};
 use fun set_target_address_util as Scenario.set_target_address_util;
 use fun set_reverse_lookup_util as Scenario.set_reverse_lookup_util;
 use fun unset_reverse_lookup_util as Scenario.unset_reverse_lookup_util;
+use fun set_avatar_util as Scenario.set_avatar_util;
+use fun set_content_hash_util as Scenario.set_content_hash_util;
 use fun set_user_data_util as Scenario.set_user_data_util;
+use fun unset_avatar_util as Scenario.unset_avatar_util;
+use fun unset_content_hash_util as Scenario.unset_content_hash_util;
 use fun unset_user_data_util as Scenario.unset_user_data_util;
 use fun lookup_util as Scenario.lookup_util;
 use fun get_user_data as Scenario.get_user_data;
+use fun get_metadata as Scenario.get_metadata;
 use fun setup as Scenario.setup;
 use fun deauthorize_util as Scenario.deauthorize_util;
 use fun reverse_lookup_util as Scenario.reverse_lookup_util;
@@ -42,6 +47,8 @@ const SECOND_ADDRESS: address = @0xB002;
 const DOMAIN_NAME: vector<u8> = b"abc.iota";
 const AVATAR: vector<u8> = b"avatar";
 const CONTENT_HASH: vector<u8> = b"content_hash";
+const USERNAME: vector<u8> = b"username";
+const WEBSITE: vector<u8> = b"website";
 const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 fun test_init(): Scenario {
@@ -141,6 +148,44 @@ public fun unset_reverse_lookup_util(scenario: &mut Scenario, sender: address) {
     test_scenario::return_shared(iota_names);
 }
 
+public fun set_avatar_util(
+    scenario: &mut Scenario,
+    sender: address,
+    value: String,
+    clock_tick: u64,
+) {
+    scenario.next_tx(sender);
+    let mut iota_names = scenario.take_shared<IotaNames>();
+    let nft = scenario.take_from_sender<IotaNamesRegistration>();
+    let mut clock = scenario.take_shared<Clock>();
+
+    clock.increment_for_testing(clock_tick);
+    controller::set_avatar(&mut iota_names, &nft, value, &clock);
+
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(iota_names);
+    scenario.return_to_sender(nft);
+}
+
+public fun set_content_hash_util(
+    scenario: &mut Scenario,
+    sender: address,
+    value: String,
+    clock_tick: u64,
+) {
+    scenario.next_tx(sender);
+    let mut iota_names = scenario.take_shared<IotaNames>();
+    let nft = scenario.take_from_sender<IotaNamesRegistration>();
+    let mut clock = scenario.take_shared<Clock>();
+
+    clock.increment_for_testing(clock_tick);
+    controller::set_content_hash(&mut iota_names, &nft, value, &clock);
+
+    test_scenario::return_shared(clock);
+    test_scenario::return_shared(iota_names);
+    scenario.return_to_sender(nft);
+}
+
 public fun set_user_data_util(
     scenario: &mut Scenario,
     sender: address,
@@ -159,6 +204,42 @@ public fun set_user_data_util(
     test_scenario::return_shared(clock);
     test_scenario::return_shared(iota_names);
     scenario.return_to_sender(nft);
+}
+
+public fun unset_avatar_util(
+    scenario: &mut Scenario,
+    sender: address,
+    clock_tick: u64,
+) {
+    scenario.next_tx(sender);
+    let mut iota_names = scenario.take_shared<IotaNames>();
+    let nft = scenario.take_from_sender<IotaNamesRegistration>();
+    let mut clock = scenario.take_shared<Clock>();
+
+    clock.increment_for_testing(clock_tick);
+    controller::unset_avatar(&mut iota_names, &nft, &clock);
+
+    test_scenario::return_shared(clock);
+    scenario.return_to_sender(nft);
+    test_scenario::return_shared(iota_names);
+}
+
+public fun unset_content_hash_util(
+    scenario: &mut Scenario,
+    sender: address,
+    clock_tick: u64,
+) {
+    scenario.next_tx(sender);
+    let mut iota_names = scenario.take_shared<IotaNames>();
+    let nft = scenario.take_from_sender<IotaNamesRegistration>();
+    let mut clock = scenario.take_shared<Clock>();
+
+    clock.increment_for_testing(clock_tick);
+    controller::unset_content_hash(&mut iota_names, &nft, &clock);
+
+    test_scenario::return_shared(clock);
+    scenario.return_to_sender(nft);
+    test_scenario::return_shared(iota_names);
 }
 
 public fun unset_user_data_util(
@@ -201,7 +282,19 @@ fun get_user_data(scenario: &mut Scenario, domain_name: String): VecMap<String, 
 
     let registry = iota_names.registry<Registry>();
     let record = extract(&mut lookup(registry, domain::new(domain_name)));
-    let data = *record.data();
+    let data = *record.user_data();
+    test_scenario::return_shared(iota_names);
+
+    data
+}
+
+fun get_metadata(scenario: &mut Scenario, domain_name: String): VecMap<String, String> {
+    scenario.next_tx(IOTA_NAMES_ADDRESS);
+    let iota_names = scenario.take_shared<IotaNames>();
+
+    let registry = iota_names.registry<Registry>();
+    let record = extract(&mut lookup(registry, domain::new(domain_name)));
+    let data = *record.metadata();
     test_scenario::return_shared(iota_names);
 
     data
@@ -413,6 +506,48 @@ fun test_unset_reverse_lookup_aborts_if_not_set() {
 }
 
 #[test]
+fun test_set_avatar() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.setup(FIRST_ADDRESS, 0);
+
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 0);
+    set_avatar_util(
+        scenario,
+        FIRST_ADDRESS,
+        b"my_avatar".to_string(),
+        0,
+    );
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 1);
+    assert_eq(*data.get(&AVATAR.to_string()), b"my_avatar".to_string());
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_set_content_hash() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.setup(FIRST_ADDRESS, 0);
+
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 0);
+    set_content_hash_util(
+        scenario,
+        FIRST_ADDRESS,
+        b"my_content_hash".to_string(),
+        0,
+    );
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 1);
+    assert_eq(*data.get(&CONTENT_HASH.to_string()), b"my_content_hash".to_string());
+
+    scenario_val.end();
+}
+
+#[test]
 fun test_set_user_data() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
@@ -423,42 +558,25 @@ fun test_set_user_data() {
     set_user_data_util(
         scenario,
         FIRST_ADDRESS,
-        AVATAR.to_string(),
-        b"value_avatar".to_string(),
+        USERNAME.to_string(),
+        b"my_username".to_string(),
         0,
     );
     let data = &scenario.get_user_data(DOMAIN_NAME.to_string());
     assert_eq(data.size(), 1);
-    assert_eq(*data.get(&AVATAR.to_string()), b"value_avatar".to_string());
+    assert_eq(*data.get(&USERNAME.to_string()), b"my_username".to_string());
 
     set_user_data_util(
         scenario,
         FIRST_ADDRESS,
-        utf8(CONTENT_HASH),
-        b"value_content_hash".to_string(),
+        utf8(WEBSITE),
+        b"http://my-website.com".to_string(),
         0,
     );
     let data = &scenario.get_user_data(DOMAIN_NAME.to_string());
     assert_eq(data.size(), 2);
-    assert_eq(*data.get(&AVATAR.to_string()), b"value_avatar".to_string());
-    assert_eq(*data.get(&utf8(CONTENT_HASH)), b"value_content_hash".to_string());
-
-    scenario_val.end();
-}
-
-#[test, expected_failure(abort_code = controller::EUnsupportedKey)]
-fun test_set_user_data_aborts_if_key_is_unsupported() {
-    let mut scenario_val = test_init();
-    let scenario = &mut scenario_val;
-    scenario.setup(FIRST_ADDRESS, 0);
-
-    set_user_data_util(
-        scenario,
-        FIRST_ADDRESS,
-        b"key".to_string(),
-        b"value".to_string(),
-        0,
-    );
+    assert_eq(*data.get(&USERNAME.to_string()), b"my_username".to_string());
+    assert_eq(*data.get(&utf8(WEBSITE)), b"http://my-website.com".to_string());
 
     scenario_val.end();
 }
@@ -472,7 +590,7 @@ fun test_set_user_data_aborts_if_nft_expired() {
     set_user_data_util(
         scenario,
         FIRST_ADDRESS,
-        AVATAR.to_string(),
+        USERNAME.to_string(),
         b"value".to_string(),
         2 * year_ms(),
     );
@@ -490,7 +608,7 @@ fun test_set_user_data_aborts_if_nft_expired_2() {
     set_user_data_util(
         scenario,
         FIRST_ADDRESS,
-        AVATAR.to_string(),
+        USERNAME.to_string(),
         b"value".to_string(),
         0,
     );
@@ -508,13 +626,13 @@ fun test_set_user_data_works_if_domain_is_registered_again() {
     set_user_data_util(
         scenario,
         SECOND_ADDRESS,
-        AVATAR.to_string(),
+        USERNAME.to_string(),
         b"value".to_string(),
         0,
     );
     let data = &scenario.get_user_data(DOMAIN_NAME.to_string());
     assert_eq(data.size(), 1);
-    assert_eq(*data.get(&AVATAR.to_string()), b"value".to_string());
+    assert_eq(*data.get(&USERNAME.to_string()), b"value".to_string());
 
     scenario_val.end();
 }
@@ -528,10 +646,46 @@ fun test_set_user_data_aborts_if_controller_is_deauthorized() {
     scenario.deauthorize_util();
     scenario.set_user_data_util(
         FIRST_ADDRESS,
-        AVATAR.to_string(),
+        USERNAME.to_string(),
         b"value_avatar".to_string(),
         0,
     );
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_unset_avatar() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.setup(FIRST_ADDRESS, 0);
+
+    scenario.set_avatar_util(
+        FIRST_ADDRESS,
+        b"value_avatar".to_string(),
+        0,
+    );
+    scenario.unset_avatar_util(FIRST_ADDRESS, 0);
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 0);
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_unset_content_hash() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.setup(FIRST_ADDRESS, 0);
+
+    scenario.set_content_hash_util(
+        FIRST_ADDRESS,
+        b"value_content_hash".to_string(),
+        0,
+    );
+    scenario.unset_content_hash_util(FIRST_ADDRESS, 0);
+    let data = &scenario.get_metadata(DOMAIN_NAME.to_string());
+    assert_eq(data.size(), 0);
 
     scenario_val.end();
 }
@@ -544,30 +698,30 @@ fun test_unset_user_data() {
 
     scenario.set_user_data_util(
         FIRST_ADDRESS,
-        AVATAR.to_string(),
-        b"value_avatar".to_string(),
+        USERNAME.to_string(),
+        b"my_username".to_string(),
         0,
     );
-    scenario.unset_user_data_util(FIRST_ADDRESS, AVATAR.to_string(), 0);
+    scenario.unset_user_data_util(FIRST_ADDRESS, USERNAME.to_string(), 0);
     let data = &scenario.get_user_data(DOMAIN_NAME.to_string());
     assert_eq(data.size(), 0);
 
     scenario.set_user_data_util(
         FIRST_ADDRESS,
-        utf8(CONTENT_HASH),
-        b"value_content_hash".to_string(),
+        utf8(WEBSITE),
+        b"http://my-website.com".to_string(),
         0,
     );
     scenario.set_user_data_util(
         FIRST_ADDRESS,
-        AVATAR.to_string(),
-        b"value_avatar".to_string(),
+        USERNAME.to_string(),
+        b"my_username".to_string(),
         0,
     );
-    scenario.unset_user_data_util(FIRST_ADDRESS, utf8(CONTENT_HASH), 0);
+    scenario.unset_user_data_util(FIRST_ADDRESS, utf8(WEBSITE), 0);
     let data = &scenario.get_user_data(DOMAIN_NAME.to_string());
     assert_eq(data.size(), 1);
-    assert_eq(*data.get(&AVATAR.to_string()), b"value_avatar".to_string());
+    assert_eq(*data.get(&USERNAME.to_string()), b"my_username".to_string());
 
     scenario_val.end();
 }
@@ -578,7 +732,7 @@ fun test_unset_user_data_works_if_key_not_exists() {
     let scenario = &mut scenario_val;
     scenario.setup(FIRST_ADDRESS, 0);
 
-    scenario.unset_user_data_util(FIRST_ADDRESS, AVATAR.to_string(), 0);
+    scenario.unset_user_data_util(FIRST_ADDRESS, USERNAME.to_string(), 0);
 
     scenario_val.end();
 }
@@ -589,7 +743,7 @@ fun test_unset_user_data_aborts_if_nft_expired() {
     let scenario = &mut scenario_val;
     scenario.setup(FIRST_ADDRESS, 0);
 
-    scenario.unset_user_data_util(FIRST_ADDRESS, AVATAR.to_string(), 2 * year_ms());
+    scenario.unset_user_data_util(FIRST_ADDRESS, USERNAME.to_string(), 2 * year_ms());
 
     scenario_val.end();
 }
@@ -601,7 +755,7 @@ fun test_unset_user_data_works_if_controller_is_deauthorized() {
     scenario.setup(FIRST_ADDRESS, 0);
 
     scenario.deauthorize_util();
-    scenario.unset_user_data_util(FIRST_ADDRESS, AVATAR.to_string(), 0);
+    scenario.unset_user_data_util(FIRST_ADDRESS, USERNAME.to_string(), 0);
 
     scenario_val.end();
 }

--- a/packages/iota-names/tests/unit/name_record_tests.move
+++ b/packages/iota-names/tests/unit/name_record_tests.move
@@ -30,7 +30,7 @@ fun create_and_update() {
 
     // check default values
     assert_eq(record.nft_id(), nft_id);
-    assert_eq(*record.data(), vec_map::empty());
+    assert_eq(*record.user_data(), vec_map::empty());
     assert_eq(record.target_address(), none());
     assert_eq(record.expiration_timestamp_ms(), 0);
 
@@ -39,13 +39,13 @@ fun create_and_update() {
     data.insert(utf8(b"age"), utf8(b"forever young"));
 
     // update values
-    record.set_data(copy data);
+    record.set_user_data(copy data);
     record.set_target_address(some(@iota_names));
     record.set_expiration_timestamp_ms(123456789); // 123456789 ms = 3.9 years
 
     // check updated values
     assert_eq(record.nft_id(), nft_id);
-    assert_eq(*record.data(), data);
+    assert_eq(*record.user_data(), data);
     assert_eq(record.target_address(), some(@iota_names));
     assert_eq(record.expiration_timestamp_ms(), 123456789);
 }

--- a/packages/subdomains/sources/subdomains.move
+++ b/packages/subdomains/sources/subdomains.move
@@ -279,7 +279,7 @@ fun internal_set_flag(self: &mut IotaNames, subdomain: Domain, key: String, enab
         config.remove(&key);
     };
 
-    registry_mut(self).set_data(subdomain, config);
+    registry_mut(self).set_metadata(subdomain, config);
 }
 
 /// Check if subdomain creation is allowed.

--- a/packages/subdomains/sources/subdomains.move
+++ b/packages/subdomains/sources/subdomains.move
@@ -294,7 +294,7 @@ fun is_extension_allowed(metadata: &VecMap<String, String>): bool {
 
 /// Get the name record's metadata for a subdomain.
 fun record_metadata(self: &IotaNames, subdomain: Domain): VecMap<String, String> {
-    *registry(self).get_data(subdomain)
+    *registry(self).get_metadata(subdomain)
 }
 
 /// Does all the regular checks for validating that a parent `IotaNamesRegistration` object

--- a/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
+++ b/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
@@ -137,3 +137,55 @@ public fun unset_user_data(
         clock,
     );
 }
+
+public fun set_avatar(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    value: String,
+    clock: &Clock,
+) {
+    controller::set_avatar(
+        iota_names,
+        subdomain.nft(),
+        value,
+        clock,
+    );
+}
+
+public fun set_content_hash(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    value: String,
+    clock: &Clock,
+) {
+    controller::set_content_hash(
+        iota_names,
+        subdomain.nft(),
+        value,
+        clock,
+    );
+}
+
+public fun unset_avatar(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    clock: &Clock,
+) {
+    controller::unset_avatar(
+        iota_names,
+        subdomain.nft(),
+        clock,
+    );
+}
+
+public fun unset_content_hash(
+    iota_names: &mut IotaNames,
+    nft: &IotaNamesRegistration,
+    clock: &Clock,
+) {
+    controller::unset_content_hash(
+        iota_names,
+        subdomain.nft(),
+        clock,
+    );
+}

--- a/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
+++ b/packages/temp-subdomain-proxy/sources/subdomain_proxy.move
@@ -140,7 +140,7 @@ public fun unset_user_data(
 
 public fun set_avatar(
     iota_names: &mut IotaNames,
-    nft: &IotaNamesRegistration,
+    subdomain: &SubdomainRegistration,
     value: String,
     clock: &Clock,
 ) {
@@ -154,7 +154,7 @@ public fun set_avatar(
 
 public fun set_content_hash(
     iota_names: &mut IotaNames,
-    nft: &IotaNamesRegistration,
+    subdomain: &SubdomainRegistration,
     value: String,
     clock: &Clock,
 ) {
@@ -168,7 +168,7 @@ public fun set_content_hash(
 
 public fun unset_avatar(
     iota_names: &mut IotaNames,
-    nft: &IotaNamesRegistration,
+    subdomain: &SubdomainRegistration,
     clock: &Clock,
 ) {
     controller::unset_avatar(
@@ -180,7 +180,7 @@ public fun unset_avatar(
 
 public fun unset_content_hash(
     iota_names: &mut IotaNames,
-    nft: &IotaNamesRegistration,
+    subdomain: &SubdomainRegistration,
     clock: &Clock,
 ) {
     controller::unset_content_hash(


### PR DESCRIPTION
## Description

Currently user data is used more like metadata, with predefined keys which are inflexible. This is counterintuitive because `user` implies that it can be set according to the user's wishes. 

This PR splits this field into two: One which has very limited access patterns for setting predefined metadata keys, and the other which allows anything.