### PR TITLE
feat(indexer): add name length distribution metric

### DIFF
--- a/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
+++ b/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
@@ -26,6 +26,138 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "length",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "name_length_distribution",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Count per second level name length",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "length"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "length"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "The IOTA balance of the IotaNames object.",
       "fieldConfig": {
         "defaults": {

--- a/indexer/src/events.rs
+++ b/indexer/src/events.rs
@@ -55,7 +55,7 @@ impl IotaNamesEvent {
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct IotaNamesRegistryEvent {
-    pub domain: String,
+    pub domain: Domain,
     pub name_record: NameRecord,
 }
 

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -5,7 +5,10 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use axum::{Extension, Router, routing::get};
 use iota_metrics::{METRICS_ROUTE, RegistryService};
-use prometheus::{IntGauge, Registry, register_int_gauge_with_registry};
+use prometheus::{
+    IntCounterVec, IntGauge, Registry, register_int_counter_vec_with_registry,
+    register_int_gauge_with_registry,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -16,6 +19,7 @@ pub(crate) struct IotaNamesMetrics {
     pub total_leaf_subdomains: IntGauge,
     pub total_auction_started: IntGauge,
     pub total_auction_finalized: IntGauge,
+    pub name_length_distribution: IntCounterVec,
 }
 
 impl IotaNamesMetrics {
@@ -54,6 +58,13 @@ impl IotaNamesMetrics {
             total_auction_finalized: register_int_gauge_with_registry!(
                 "total_auction_finalized",
                 "The total number of auction that were finalized",
+                registry,
+            )
+            .unwrap(),
+            name_length_distribution: register_int_counter_vec_with_registry!(
+                "name_length_distribution",
+                "The length of second level names",
+                &["length"],
                 registry,
             )
             .unwrap(),

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    panic::AssertUnwindSafe,
+};
 
 use axum::{Extension, Router, routing::get};
 use iota_metrics::{METRICS_ROUTE, RegistryService};
@@ -19,7 +22,7 @@ pub(crate) struct IotaNamesMetrics {
     pub total_leaf_subdomains: IntGauge,
     pub total_auction_started: IntGauge,
     pub total_auction_finalized: IntGauge,
-    pub name_length_distribution: IntCounterVec,
+    pub name_length_distribution: AssertUnwindSafe<IntCounterVec>,
 }
 
 impl IotaNamesMetrics {
@@ -61,13 +64,15 @@ impl IotaNamesMetrics {
                 registry,
             )
             .unwrap(),
-            name_length_distribution: register_int_counter_vec_with_registry!(
-                "name_length_distribution",
-                "The length of second level names",
-                &["length"],
-                registry,
-            )
-            .unwrap(),
+            name_length_distribution: AssertUnwindSafe(
+                register_int_counter_vec_with_registry!(
+                    "name_length_distribution",
+                    "The length of second level names",
+                    &["length"],
+                    registry,
+                )
+                .unwrap(),
+            ),
         }
     }
 }

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -10,7 +10,7 @@ use iota_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
 };
 use iota_json::IotaJsonValue;
-use iota_names::config::IotaNamesConfig;
+use iota_names::{config::IotaNamesConfig, domain::Domain};
 use iota_types::{
     Identifier, TypeTag,
     balance::Balance,
@@ -87,8 +87,14 @@ impl IotaNamesWorker {
 
     fn process_event(&self, event: IotaNamesEvent) -> anyhow::Result<()> {
         match event {
-            IotaNamesEvent::IotaNamesRegistry(_event) => {
+            IotaNamesEvent::IotaNamesRegistry(event) => {
                 self.metrics.total_name_records.inc();
+                let domain = Domain::from_str(&event.domain)?;
+                let second_level_name_len = domain.label(1).expect("missing SDL").len();
+                self.metrics
+                    .name_length_distribution
+                    .with_label_values(&[&second_level_name_len.to_string()])
+                    .inc();
             }
             IotaNamesEvent::IotaNamesReverseRegistry(_event) => (),
             IotaNamesEvent::AuctionStarted(_event) => {

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -90,7 +90,7 @@ impl IotaNamesWorker {
             IotaNamesEvent::IotaNamesRegistry(event) => {
                 self.metrics.total_name_records.inc();
                 let domain = Domain::from_str(&event.domain)?;
-                let second_level_name_len = domain.label(1).expect("missing SDL").len();
+                let second_level_name_len = domain.label(1).expect("missing SLD").len();
                 self.metrics
                     .name_length_distribution
                     .with_label_values(&[&second_level_name_len.to_string()])

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -10,7 +10,7 @@ use iota_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
 };
 use iota_json::IotaJsonValue;
-use iota_names::{config::IotaNamesConfig, domain::Domain};
+use iota_names::config::IotaNamesConfig;
 use iota_types::{
     Identifier, TypeTag,
     balance::Balance,
@@ -89,8 +89,7 @@ impl IotaNamesWorker {
         match event {
             IotaNamesEvent::IotaNamesRegistry(event) => {
                 self.metrics.total_name_records.inc();
-                let domain = Domain::from_str(&event.domain)?;
-                let second_level_name_len = domain.label(1).expect("missing SLD").len();
+                let second_level_name_len = event.domain.label(1).expect("missing SLD").len();
                 self.metrics
                     .name_length_distribution
                     .with_label_values(&[&second_level_name_len.to_string()])

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -51,7 +51,7 @@ public struct Registry has store {
 }
 
 public struct IotaNamesRegistryEvent has copy, drop {
-    domain: String,
+    domain: Domain,
     name_record: NameRecord
 }
 
@@ -189,7 +189,7 @@ public fun add_leaf_record(
     let name_record = name_record::new_leaf(parent_name_record.nft_id(), some(target));
 
     event::emit(IotaNamesRegistryEvent {
-        domain: domain.to_string(),
+        domain,
         name_record
     });
 
@@ -368,7 +368,7 @@ fun internal_add_record(
     );
     
     event::emit(IotaNamesRegistryEvent {
-        domain: domain.to_string(),
+        domain,
         name_record
     });
 


### PR DESCRIPTION
Add a new metric to track the count of registered names with for the length of the second level name

Fixes https://github.com/iotaledger/iota/issues/7031

Tested in a localnet:
![image](https://github.com/user-attachments/assets/f1524412-9fee-45cc-b770-c73f62f8b08e)
