### PR TITLE
fix(indexer): change metrics port to 9189, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ iota start --force-regenesis --with-faucet
 2. In another terminal, create a new environment for the local network and switch to it:
 
 ```bash
-iota client new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:8000
+iota client new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:9125
 iota client switch --env localnet
 ```
 
@@ -72,12 +72,13 @@ iota name register first.iota
 All in one:
 
 ```bash
+docker run -d --name postgres -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_INITDB_ARGS="-U postgres" -p 5432:5432 postgres:15 -c max_connections=1000
 # Run network in the background without logs
-iota start --force-regenesis --with-faucet --committee-size 2 > /dev/null 2>&1 &
-iota client new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:8000
+iota start --force-regenesis --with-faucet --committee-size 2 --with-indexer --with-graphql > /dev/null 2>&1 &
+iota client new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:9125
 iota client switch --env localnet
 # wait for the network to start
-sleep 5
+sleep 10
 iota client faucet
 # wait for the faucet tx
 sleep 2

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -6,7 +6,7 @@ Indexer to collect metrics about IOTA-Names.
 
 ### Run a local network with IOTA-Names deployed
 
-../README.md#local-setup-for-testing
+Follow the instructions from the [root README](../README.md#local-setup-for-testing)
 
 ### Set the environment variables
 
@@ -26,7 +26,7 @@ Add `--build` to rebuild the indexer image.
 
 The following endpoints will be available:
 
-- **IOTA Names Indexer Metrics:** [http://localhost:9184/metrics](http://localhost:9184/metrics)
+- **IOTA Names Indexer Metrics:** [http://localhost:9189/metrics](http://localhost:9189/metrics)
 - **Prometheus:** [http://localhost:9090](http://localhost:9090)
 - **Grafana:** [http://localhost:3000](http://localhost:3000)
 

--- a/indexer/docker/Dockerfile
+++ b/indexer/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update && apt install -y cmake clang lld
 
 # Configure Rust to use clang and lld as the linker
 RUN mkdir -p ~/.cargo && \
-    echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
+  echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
 
 # Install additional dependencies
 RUN apt install -y libpq5 libpq-dev ca-certificates
@@ -30,13 +30,13 @@ RUN cargo build --profile ${PROFILE} --features ${CARGO_BUILD_FEATURES:=default}
 # so we can copy it to the runtime image
 RUN if [ -d target/release ]; then \
   TARGET_DIR="target/release"; \
-elif [ -d target/debug ]; then \
+  elif [ -d target/debug ]; then \
   TARGET_DIR="target/debug"; \
-else \
+  else \
   echo "Error: No build directory found"; \
   exit 1; \
-fi && \
-mv $TARGET_DIR/iota-names-indexer ./;
+  fi && \
+  mv $TARGET_DIR/iota-names-indexer ./;
 
 # Production image
 FROM debian:bookworm-slim AS runtime
@@ -51,6 +51,6 @@ ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE
 LABEL git-revision=$GIT_REVISION
 
-EXPOSE 9184/tcp
+EXPOSE 9189/tcp
 
 ENTRYPOINT ["/usr/local/bin/iota-names-indexer"]

--- a/indexer/docker/assets/prometheus/prometheus.yml
+++ b/indexer/docker/assets/prometheus/prometheus.yml
@@ -4,4 +4,4 @@ global:
 scrape_configs:
   - job_name: "iota_names_indexer"
     static_configs:
-      - targets: ["iota-names-indexer:9184"]
+      - targets: ["iota-names-indexer:9189"]

--- a/indexer/docker/docker-compose.yml
+++ b/indexer/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         - PROFILE=dev
     image: iota-names-indexer:dev
     ports:
-      - "9184:9184/tcp" # Metrics
+      - "9189:9189/tcp" # Metrics
     tty: true
     deploy:
       restart_policy:

--- a/indexer/prometheus.yml
+++ b/indexer/prometheus.yml
@@ -1,4 +1,4 @@
 scrape_configs:
   - job_name: "iota_names"
     static_configs:
-      - targets: ["172.17.0.1:9184"]
+      - targets: ["172.17.0.1:9189"]

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -45,7 +45,7 @@ impl PrometheusServer {
     }
 
     pub(crate) async fn start(&self, token: CancellationToken) -> anyhow::Result<()> {
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9184);
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9189);
         info!("Starting prometheus metrics at {addr}");
 
         let app = Router::new()


### PR DESCRIPTION
I changed the metrics port to 9189, because everything from 9184-9188 is already used for different metrics in the iota repository and running another service at the same time would then lead to issues as the port is already used. This happens already when we run the localnet with the indexer. 
Graphql has 9125 as default port, so I also fixed that