### PR TITLE
fix(tooling): Ignore `indexer` folder in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,4 @@ dprint.json
 pnpm-workspace.yaml
 .prettierrc
 packages
+indexer


### PR DESCRIPTION
Regression of https://github.com/iotaledger/iota-names/pull/224/files

fixes https://github.com/iotaledger/iota-names/actions/runs/15418013494/job/43385363845?pr=226