### PR TITLE
fix(docker): add cache bust, so it compiles the actual binary

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -18,7 +18,7 @@ cd scripts && pnpm ts-node utils/envs.ts localnet > ../indexer/docker/.env && cd
 ### Build the indexer image
 
 ```bash
-docker compose -f indexer/docker/docker-compose.yml build
+docker compose -f indexer/docker/docker-compose.yml build --build-arg CACHEBUST=$(date +%s)
 ```
 
 Rust dependencies are cached by the Cargo.toml/Cargo.lock files, use `--no-cache` to force a full rebuild.

--- a/indexer/docker/Dockerfile
+++ b/indexer/docker/Dockerfile
@@ -37,6 +37,8 @@ RUN rm -rf src
 # 5. Copy the rest of the source code
 COPY ./ .
 
+ARG CACHEBUST=1
+RUN echo "Cache bust: $CACHEBUST" && touch src/main.rs
 # 6. Build the actual project
 RUN cargo build --profile ${PROFILE} --features ${CARGO_BUILD_FEATURES:=default}
 


### PR DESCRIPTION
Tested with `DOCKER_BUILDKIT=1 docker compose -f indexer/docker/docker-compose.yml build --build-arg CACHEBUST=$(date +%s) --progress=plain`
The main.rs timestamp had to be updated with `touch src/main.rs`, otherwise cargo wouldn't notice that there was a change