### PR TITLE
feat(indexer): add auction_final_prices metric

### DIFF
--- a/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
+++ b/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
@@ -1087,6 +1087,77 @@
       ],
       "title": "Final auction prices",
       "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "/^Value$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "(auction_final_prices_sum/auction_final_prices_count)/1000000000",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Average auction price in IOTA",
+      "type": "stat"
     }
   ],
   "preload": false,

--- a/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
+++ b/indexer/docker/assets/grafana/dashboards/iota_names_dashboard.json
@@ -998,6 +998,95 @@
       ],
       "title": "Number of auctions started and finalized",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Bucket size is 10 IOTA",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 12,
+      "options": {
+        "bucketSize": 10000000000,
+        "combine": false,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "auction_final_prices",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Final auction prices",
+      "type": "histogram"
     }
   ],
   "preload": false,

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -104,7 +104,7 @@ impl IotaNamesMetrics {
             ),
             auction_final_prices: Histogram::new_in_registry(
                 "auction_final_prices",
-                "The final price paid for a domain in auctions",
+                "The final prices paid for domains in auctions",
                 registry,
             ),
         }

--- a/indexer/src/metrics.rs
+++ b/indexer/src/metrics.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use axum::{Extension, Router, routing::get};
-use iota_metrics::{METRICS_ROUTE, RegistryService};
+use iota_metrics::{METRICS_ROUTE, RegistryService, histogram::Histogram};
 use prometheus::{
     IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
@@ -27,6 +27,7 @@ pub(crate) struct IotaNamesMetrics {
     pub name_length_distribution: AssertUnwindSafe<IntGaugeVec>,
     pub renewal_years_distribution: AssertUnwindSafe<IntCounterVec>,
     pub name_depth_distribution: AssertUnwindSafe<IntGaugeVec>,
+    pub auction_final_prices: Histogram,
 }
 
 impl IotaNamesMetrics {
@@ -100,6 +101,11 @@ impl IotaNamesMetrics {
                     registry,
                 )
                 .unwrap(),
+            ),
+            auction_final_prices: Histogram::new_in_registry(
+                "auction_final_prices",
+                "The final price paid for a domain in auctions",
+                registry,
             ),
         }
     }

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -152,8 +152,9 @@ impl IotaNamesWorker {
             }
             IotaNamesEvent::AuctionBid(_event) => (),
             IotaNamesEvent::AuctionExtended(_event) => (),
-            IotaNamesEvent::AuctionFinalized(_event) => {
+            IotaNamesEvent::AuctionFinalized(event) => {
                 self.metrics.total_auction_finalized.inc();
+                self.metrics.auction_final_prices.observe(event.winning_bid);
             }
             IotaNamesEvent::NodeSubdomainCreated(_event) => {
                 self.metrics.total_node_subdomains.inc();


### PR DESCRIPTION
Add metric for the final price that was paid in auctions for names and grafana histogram view for it
![image](https://github.com/user-attachments/assets/09a7160a-fa3a-40e6-ab95-bf30b4058a98)
and average price
![image](https://github.com/user-attachments/assets/868f60b5-bf82-4ad6-8170-d8514746b224)


Closes https://github.com/iotaledger/iota/issues/7139