### PR TITLE
feat: Allow passing string coupon hashes

### DIFF
--- a/packages/coupons/sources/coupon_house.move
+++ b/packages/coupons/sources/coupon_house.move
@@ -214,7 +214,7 @@ public fun assert_version_is_valid(self: &CouponHouse) {
 public fun admin_add_percentage_coupon(
     _: &AdminCap,
     iota_names: &mut IotaNames,
-    hash: vector<u8>,
+    hash: String,
     amount: u64,
     rules: CouponRules,
 ) {
@@ -228,7 +228,7 @@ public fun admin_add_percentage_coupon(
 public fun admin_add_fixed_coupon(
     _: &AdminCap,
     iota_names: &mut IotaNames,
-    hash: vector<u8>,
+    hash: String,
     amount: u64,
     rules: CouponRules,
 ) {
@@ -238,7 +238,7 @@ public fun admin_add_fixed_coupon(
 }
 
 // Remove a coupon as a system's admin.
-public fun admin_remove_coupon(_: &AdminCap, iota_names: &mut IotaNames, hash: vector<u8>) {
+public fun admin_remove_coupon(_: &AdminCap, iota_names: &mut IotaNames, hash: String) {
     let coupon_house = coupon_house_mut(iota_names);
     coupon_house.assert_version_is_valid();
     coupon_house.coupons.remove_coupon(hash);

--- a/packages/coupons/sources/coupons.move
+++ b/packages/coupons/sources/coupons.move
@@ -4,9 +4,12 @@
 
 module iota_names_coupons::coupons;
 
+use iota::hex;
 use iota::table::{Self, Table};
 use iota_names_coupons::coupon::{Self, Coupon};
 use iota_names_coupons::rules::CouponRules;
+
+use std::string::String;
 
 #[error]
 const ECouponAlreadyExists: vector<u8> = b"Coupon already exists.";
@@ -31,7 +34,7 @@ public(package) fun new(ctx: &mut TxContext): Coupons {
 // Add percentaged based coupon.
 public fun add_percentage_coupon(
     self: &mut Coupons,
-    hash: vector<u8>,
+    hash: String,
     percentage: u64,
     rules: CouponRules,
 ) {
@@ -41,7 +44,7 @@ public fun add_percentage_coupon(
 // Add fixed amount coupon.
 public fun add_fixed_coupon(
     self: &mut Coupons,
-    hash: vector<u8>,
+    hash: String,
     amount: u64,
     rules: CouponRules,
 ) {
@@ -49,14 +52,16 @@ public fun add_fixed_coupon(
 }
 
 // A function to remove a coupon from the system.
-public(package) fun remove_coupon(self: &mut Coupons, hash: vector<u8>) {
+public(package) fun remove_coupon(self: &mut Coupons, hash: String) {
+    let hash = hex::decode(hash.into_bytes());
     assert!(self.coupons.contains(hash), ECouponDoesNotExist);
     let _: Coupon = self.coupons.remove(hash);
 }
 
 /// Private internal functions
 /// An internal function to save the coupon in the shared object's config.
-public(package) fun save_coupon(self: &mut Coupons, hash: vector<u8>, coupon: Coupon) {
+public(package) fun save_coupon(self: &mut Coupons, hash: String, coupon: Coupon) {
+    let hash = hex::decode(hash.into_bytes());
     assert!(!self.coupons.contains(hash), ECouponAlreadyExists);
     self.coupons.add(hash, coupon);
 }

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -7,6 +7,7 @@ module iota_names_coupons::coupon_tests;
 
 use iota::clock::Clock;
 use iota::hash::blake2b256;
+use iota::hex;
 use iota::test_scenario::{Scenario, return_shared};
 use iota::test_utils::{Self, destroy};
 use iota_names::iota_names::IotaNames;
@@ -526,7 +527,7 @@ fun add_coupon_twice_failure() {
 fun remove_non_existing_coupon() {
     let mut ctx = tx_context::dummy();
     let mut data = coupons::new(&mut ctx);
-    data.remove_coupon(blake2b256(&b"TEST_SUCCESS_ADDITION"));
+    data.remove_coupon(hex::encode(blake2b256(&b"TEST_SUCCESS_ADDITION")).to_string());
     test_utils::destroy(data);
 }
 

--- a/packages/coupons/tests/setup.move
+++ b/packages/coupons/tests/setup.move
@@ -7,6 +7,7 @@ module iota_names_coupons::setup;
 
 use iota::clock;
 use iota::hash::blake2b256;
+use iota::hex;
 use iota::test_scenario::{Self, Scenario, ctx};
 use iota_names::iota_names::{Self, AdminCap, IotaNames};
 use iota_names::registry;
@@ -87,7 +88,7 @@ public fun unauthorized_test_app(): UnauthorizedTestAuth {
 public fun populate_coupons(data_mut: &mut Coupons) {
     // 25% DISCOUNT, ONLY FOR 2 YEARS OR LESS REGISTRATIONS
     data_mut.add_percentage_coupon(
-        blake2b256(&b"25_PERCENT_DISCOUNT_MAX_2_YEARS"),
+        hex::encode(blake2b256(&b"25_PERCENT_DISCOUNT_MAX_2_YEARS")).to_string(),
         25, // 25%
         rules::new_coupon_rules(
             option::none(),
@@ -101,7 +102,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 25% DISCOUNT, only claimable ONCE by a specific user
     data_mut.add_percentage_coupon(
-        blake2b256(&b"25_PERCENT_DISCOUNT_USER_ONLY"),
+        hex::encode(blake2b256(&b"25_PERCENT_DISCOUNT_USER_ONLY")).to_string(),
         25, // 25%
         rules::new_coupon_rules(
             option::none(),
@@ -115,7 +116,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 50% DISCOUNT, only claimable only for names > 5 digits
     data_mut.add_percentage_coupon(
-        blake2b256(&b"50_PERCENT_5_PLUS_NAMES"),
+        hex::encode(blake2b256(&b"50_PERCENT_5_PLUS_NAMES")).to_string(),
         50, // 25%
         rules::new_coupon_rules(
             option::some(range::new(5, 63)),
@@ -129,7 +130,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 50% DISCOUNT, only for 3 digit names
     data_mut.add_percentage_coupon(
-        blake2b256(&b"50_PERCENT_3_DIGITS"),
+        hex::encode(blake2b256(&b"50_PERCENT_3_DIGITS")).to_string(),
         50, // 50%
         rules::new_coupon_rules(
             option::some(range::new(3, 3)),
@@ -143,7 +144,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 50% DISCOUNT, has all rules so we can test combinations!
     data_mut.add_percentage_coupon(
-        blake2b256(&b"50_DISCOUNT_SALAD"),
+        hex::encode(blake2b256(&b"50_DISCOUNT_SALAD")).to_string(),
         50, // 50%
         rules::new_coupon_rules(
             option::some(range::new(3, 4)),
@@ -157,7 +158,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 5% DISCOUNT, can be stacked
     data_mut.add_percentage_coupon(
-        blake2b256(&b"5_DISCOUNT_STACKABLE"),
+        hex::encode(blake2b256(&b"5_DISCOUNT_STACKABLE")).to_string(),
         5, // 5%
         rules::new_coupon_rules(
             option::none(),
@@ -171,7 +172,7 @@ public fun populate_coupons(data_mut: &mut Coupons) {
 
     // 1 IOTA DISCOUNT
     data_mut.add_fixed_coupon(
-        blake2b256(&b"ONE_IOTA_OFF"),
+        hex::encode(blake2b256(&b"ONE_IOTA_OFF")).to_string(),
         nanos_per_iota(),
         rules::new_coupon_rules(
             option::none(),
@@ -186,11 +187,11 @@ public fun populate_coupons(data_mut: &mut Coupons) {
     // THESE last two are just for easy coverage.
     // We just add + remove the coupon immediately.
     data_mut.add_percentage_coupon(
-        blake2b256(&b"REMOVE_FOR_COVERAGE"),
+        hex::encode(blake2b256(&b"REMOVE_FOR_COVERAGE")).to_string(),
         50,
         rules::new_empty_rules(),
     );
-    data_mut.remove_coupon(blake2b256(&b"REMOVE_FOR_COVERAGE"));
+    data_mut.remove_coupon(hex::encode(blake2b256(&b"REMOVE_FOR_COVERAGE")).to_string());
 }
 
 // Adds a percentage based coupon that gives a discount to test admin additions.
@@ -198,7 +199,7 @@ public fun admin_add_percentage_coupon(code_name: String, value: u64, scenario: 
     scenario.next_tx(admin());
     let mut iota_names = scenario.take_shared<IotaNames>();
     let cap = scenario.take_from_sender<AdminCap>();
-    let hash = blake2b256(code_name.as_bytes());
+    let hash = hex::encode(blake2b256(code_name.as_bytes())).to_string();
     coupon_house::admin_add_percentage_coupon(
         &cap,
         &mut iota_names,
@@ -215,7 +216,7 @@ public fun admin_add_fixed_coupon(code_name: String, value: u64, scenario: &mut 
     scenario.next_tx(admin());
     let mut iota_names = scenario.take_shared<IotaNames>();
     let cap = scenario.take_from_sender<AdminCap>();
-    let hash = blake2b256(code_name.as_bytes());
+    let hash = hex::encode(blake2b256(code_name.as_bytes())).to_string();
     coupon_house::admin_add_fixed_coupon(
         &cap,
         &mut iota_names,
@@ -232,7 +233,7 @@ public fun admin_remove_coupon(code_name: String, scenario: &mut Scenario) {
     scenario.next_tx(admin());
     let mut iota_names = scenario.take_shared<IotaNames>();
     let cap = scenario.take_from_sender<AdminCap>();
-    let hash = blake2b256(code_name.as_bytes());
+    let hash = hex::encode(blake2b256(code_name.as_bytes())).to_string();
     coupon_house::admin_remove_coupon(
         &cap,
         &mut iota_names,


### PR DESCRIPTION
## Description

Allow passing hex strings instead of byte array to the coupon admin methods.

Closes #279