### PR TITLE
feat(packages): remove redundant app authorization checks

### DIFF
--- a/packages/auction/sources/auction.move
+++ b/packages/auction/sources/auction.move
@@ -85,8 +85,6 @@ public fun start_auction_and_place_bid(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    iota_names.assert_is_authorized<AuctionAuth>();
-
     let domain = domain::new(domain_name);
 
     iota_names.get_config<CoreConfig>().assert_is_valid_for_sale(&domain);

--- a/packages/coupons/sources/coupon_house.move
+++ b/packages/coupons/sources/coupon_house.move
@@ -282,8 +282,6 @@ fun coupon_house(iota_names: &IotaNames): &CouponHouse {
 
 /// Gets a mutable reference to the coupon house
 public(package) fun coupon_house_mut(iota_names: &mut IotaNames): &mut CouponHouse {
-    // Verify coupon house is authorized to get the registry / register names.
-    iota_names.assert_is_authorized<CouponsAuth>();
     let coupons = iota_names::auth_registry_mut<CouponsAuth, CouponHouse>(
         CouponsAuth {},
         iota_names,

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -109,7 +109,6 @@ public fun finalize_payment<A: drop, T>(
     app: A,
     coin: Coin<T>,
 ): Receipt {
-    iota_names.assert_is_authorized<A>();
     event::emit(intent.to_event<A, T>(coin.value()));
     iota_names.auth_add_balance(app, coin.into_balance());
 


### PR DESCRIPTION
Remove redundant app authorization checks, each function checked the authorization for the provided app type twice.

For `iota_names.assert_is_authorized<AuctionAuth>();` and `let registry = iota_names::auth_registry_mut<AuctionAuth, Registry>(AuctionAuth {}, iota_names);`
```move
public fun auth_registry_mut<Auth: drop, R: store>(_: Auth, self: &mut IotaNames): &mut R {
    self.assert_is_authorized<Auth>();
```
since `auth_registry_mut()` is called which also calls `self.assert_is_authorized<Auth>();`, the other `assert_is_authorized()` check can be safely removed 

In `coupon_house_mut()`, `iota_names::auth_registry_mut<CouponsAuth, CouponHouse>` is enough
and in `finalize_payment()`, `iota_names.auth_add_balance(app` does the check


Fixes https://github.com/iotaledger/iota-names/issues/38