### PR TITLE
feat(iota-names): add calculate_base_price_with_domain()

### DIFF
--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -136,7 +136,7 @@ public fun init_registration(iota_names: &mut IotaNames, domain: String): Paymen
     let domain = domain::new(domain);
     iota_names.get_config<CoreConfig>().assert_is_valid_for_sale(&domain);
 
-    let price = iota_names.get_config<PricingConfig>().calculate_base_price_with_domain(domain);
+    let price = iota_names.get_config<PricingConfig>().calculate_base_price_of_domain(domain);
 
     PaymentIntent::Registration(RequestData {
         domain,
@@ -161,7 +161,7 @@ public fun init_renewal(
     let price = iota_names
         .get_config<RenewalConfig>()
         .config()
-        .calculate_base_price_with_domain(domain);
+        .calculate_base_price_of_domain(domain);
 
     PaymentIntent::Renewal(RequestData {
         domain,

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -136,7 +136,7 @@ public fun init_registration(iota_names: &mut IotaNames, domain: String): Paymen
     let domain = domain::new(domain);
     iota_names.get_config<CoreConfig>().assert_is_valid_for_sale(&domain);
 
-    let price = iota_names.get_config<PricingConfig>().calculate_base_price(domain.sld().length());
+    let price = iota_names.get_config<PricingConfig>().calculate_base_price_with_domain(domain);
 
     PaymentIntent::Registration(RequestData {
         domain,
@@ -161,7 +161,7 @@ public fun init_renewal(
     let price = iota_names
         .get_config<RenewalConfig>()
         .config()
-        .calculate_base_price(domain.sld().length());
+        .calculate_base_price_with_domain(domain);
 
     PaymentIntent::Renewal(RequestData {
         domain,

--- a/packages/iota-names/sources/sales/pricing_config.move
+++ b/packages/iota-names/sources/sales/pricing_config.move
@@ -43,9 +43,9 @@ public fun calculate_base_price(config: &PricingConfig, length: u64): u64 {
     *config.pricing.get(&range)
 }
 
-/// Calculates the base price for a given domain based on its SLD length.
+/// Calculates the base price of a given domain based on its SLD length.
 /// For example, "my-name.iota" uses length 7 (the length of "my-name").
-public fun calculate_base_price_with_domain(config: &PricingConfig, domain: Domain): u64 {
+public fun calculate_base_price_of_domain(config: &PricingConfig, domain: Domain): u64 {
     calculate_base_price(config, domain.sld().length())
 }
 

--- a/packages/iota-names/sources/sales/pricing_config.move
+++ b/packages/iota-names/sources/sales/pricing_config.move
@@ -5,6 +5,7 @@
 module iota_names::pricing_config;
 
 use iota::vec_map::{Self, VecMap};
+use iota_names::domain::Domain;
 
 #[error]
 const EInvalidLength: vector<u8> = b"Tried to create a range with more than two values.";
@@ -30,7 +31,6 @@ public struct RenewalConfig has drop, store { config: PricingConfig }
 
 /// Calculates the base price for a given length.
 /// - Base price type is abstracted away. We can switch to a different base.
-///  Our core base will become USDC.
 /// - The price is calculated based on the length of the domain name and the
 /// available ranges.
 public fun calculate_base_price(config: &PricingConfig, length: u64): u64 {
@@ -41,6 +41,12 @@ public fun calculate_base_price(config: &PricingConfig, length: u64): u64 {
     let range = keys[idx.extract()];
 
     *config.pricing.get(&range)
+}
+
+/// Calculates the base price for a given domain based on its SLD length.
+/// For example, "my-name.iota" uses length 7 (the length of "my-name").
+public fun calculate_base_price_with_domain(config: &PricingConfig, domain: Domain): u64 {
+    calculate_base_price(config, domain.sld().length())
 }
 
 /// Creates a new PricingConfig with the given ranges and prices.

--- a/packages/iota-names/tests/payments/pricing_tests.move
+++ b/packages/iota-names/tests/payments/pricing_tests.move
@@ -6,6 +6,7 @@
 module iota_names::pricing_config_tests;
 
 use iota_names::pricing_config;
+use iota_names::domain;
 
 #[test]
 fun test_e2e() {
@@ -106,4 +107,47 @@ fun test_price_not_set() {
     let pricing = pricing_config::new(ranges, vector[10]);
 
     pricing.calculate_base_price(20);
+}
+
+#[test]
+fun test_calculate_base_price_with_domain() {
+    let ranges = vector[
+        pricing_config::new_range(vector[1, 10]),
+        pricing_config::new_range(vector[11, 20]),
+        pricing_config::new_range(vector[21, 21]),
+    ];
+
+    let pricing_config = pricing_config::new(
+        ranges,
+        vector[10, 20, 30],
+    );
+
+    let domain_short = domain::new(b"5char.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_short) == 10);
+
+    let domain_medium = domain::new(b"15char-----name.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_medium) == 20);
+
+    // Test boundary values
+    let domain_boundary_0 = domain::new(b"1.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_0) == 10);
+
+    let domain_boundary_1 = domain::new(b"10charname.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_1) == 10);
+
+    let domain_boundary_2 = domain::new(b"11char-name.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_2) == 20);
+
+    let domain_boundary_3 = domain::new(b"21char-----------name.iota".to_string());
+    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_3) == 30);
+}
+
+#[test, expected_failure(abort_code = ::iota_names::pricing_config::EPriceNotSet)]
+fun test_calculate_base_price_with_domain_price_not_set() {
+    let ranges = vector[pricing_config::new_range(vector[1, 10])];
+    let pricing = pricing_config::new(ranges, vector[10]);
+    
+    // Test domain with length outside configured range
+    let domain_out_of_range = domain::new(b"15-out-of-range.iota".to_string());
+    pricing.calculate_base_price_with_domain(domain_out_of_range);
 }

--- a/packages/iota-names/tests/payments/pricing_tests.move
+++ b/packages/iota-names/tests/payments/pricing_tests.move
@@ -110,7 +110,7 @@ fun test_price_not_set() {
 }
 
 #[test]
-fun test_calculate_base_price_with_domain() {
+fun test_calculate_base_price_of_domain() {
     let ranges = vector[
         pricing_config::new_range(vector[1, 10]),
         pricing_config::new_range(vector[11, 20]),
@@ -123,31 +123,31 @@ fun test_calculate_base_price_with_domain() {
     );
 
     let domain_short = domain::new(b"5char.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_short) == 10);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_short) == 10);
 
     let domain_medium = domain::new(b"15char-----name.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_medium) == 20);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_medium) == 20);
 
     // Test boundary values
     let domain_boundary_0 = domain::new(b"1.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_0) == 10);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_boundary_0) == 10);
 
     let domain_boundary_1 = domain::new(b"10charname.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_1) == 10);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_boundary_1) == 10);
 
     let domain_boundary_2 = domain::new(b"11char-name.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_2) == 20);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_boundary_2) == 20);
 
     let domain_boundary_3 = domain::new(b"21char-----------name.iota".to_string());
-    assert!(pricing_config.calculate_base_price_with_domain(domain_boundary_3) == 30);
+    assert!(pricing_config.calculate_base_price_of_domain(domain_boundary_3) == 30);
 }
 
 #[test, expected_failure(abort_code = ::iota_names::pricing_config::EPriceNotSet)]
-fun test_calculate_base_price_with_domain_price_not_set() {
+fun test_calculate_base_price_of_domain_price_not_set() {
     let ranges = vector[pricing_config::new_range(vector[1, 10])];
     let pricing = pricing_config::new(ranges, vector[10]);
     
     // Test domain with length outside configured range
     let domain_out_of_range = domain::new(b"15-out-of-range.iota".to_string());
-    pricing.calculate_base_price_with_domain(domain_out_of_range);
+    pricing.calculate_base_price_of_domain(domain_out_of_range);
 }

--- a/packages/iota-names/tests/test_utils/register.move
+++ b/packages/iota-names/tests/test_utils/register.move
@@ -48,7 +48,7 @@ public fun register<T>(
 
     assert!(0 < no_years && no_years <= 5, EInvalidYearsArgument);
 
-    let price = config.calculate_base_price_with_domain(domain) * (no_years as u64);
+    let price = config.calculate_base_price_of_domain(domain) * (no_years as u64);
     assert!(payment.value() == price, EIncorrectAmount);
 
     iota_names.auth_add_balance<_, T>(RegisterAuth {}, payment.into_balance());

--- a/packages/iota-names/tests/test_utils/register.move
+++ b/packages/iota-names/tests/test_utils/register.move
@@ -48,8 +48,7 @@ public fun register<T>(
 
     assert!(0 < no_years && no_years <= 5, EInvalidYearsArgument);
 
-    let label = domain.sld();
-    let price = config.calculate_base_price(label.length()) * (no_years as u64);
+    let price = config.calculate_base_price_with_domain(domain) * (no_years as u64);
     assert!(payment.value() == price, EIncorrectAmount);
 
     iota_names.auth_add_balance<_, T>(RegisterAuth {}, payment.into_balance());


### PR DESCRIPTION
Add calculate_base_price_with_domain() so one can provide a domain and doesn't has to compute the SLD length

Closes https://github.com/iotaledger/iota-names/issues/189