### PR TITLE
feat(indexer): use remote_store to sync

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -841,8 +841,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "const-str",
  "git-version",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -2221,7 +2221,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "serde_yaml",
 ]
@@ -3464,7 +3464,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3492,8 +3492,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3557,8 +3557,8 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3591,8 +3591,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "serde_yaml",
 ]
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3617,8 +3617,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3631,8 +3631,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3642,12 +3642,13 @@ dependencies = [
  "iota-types",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3657,8 +3658,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3674,8 +3675,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3694,8 +3695,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3727,8 +3728,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3746,8 +3747,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3757,8 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3783,8 +3784,8 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3808,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "bcs",
  "better_any",
@@ -3830,8 +3831,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3872,8 +3873,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anemo",
  "bcs",
@@ -3899,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "schemars",
  "serde",
@@ -3910,8 +3911,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3923,14 +3924,14 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -3941,8 +3942,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3959,8 +3960,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3970,8 +3971,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3985,8 +3986,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3995,8 +3996,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4028,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3e4a47351cdd774dd2895a2552a038fe2f4b6da5#3e4a47351cdd774dd2895a2552a038fe2f4b6da5"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6bb6e45fea2c266f9c15dd89f26f68631c2d37a8#6bb6e45fea2c266f9c15dd89f26f68631c2d37a8"
 dependencies = [
  "base64ct",
  "bcs",
@@ -4079,8 +4080,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4114,8 +4115,8 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4137,8 +4138,8 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4191,8 +4192,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4208,8 +4209,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4250,7 +4251,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-rational",
  "num-traits",
- "num_enum",
  "once_cell",
  "packable",
  "parking_lot 0.12.4",
@@ -4278,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "iota-protocol-config",
  "iota-types",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5040,12 +5040,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5059,12 +5059,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5080,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -5094,7 +5094,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5119,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5175,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5198,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5281,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -5294,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5307,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5327,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -5362,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5371,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5386,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "once_cell",
  "phf",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5407,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5426,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "better_any",
  "fail",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6672,8 +6672,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7844,8 +7844,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "bcs",
  "eyre",
@@ -8321,8 +8321,8 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -9021,8 +9021,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "async-trait",
  "bcs",
@@ -9050,8 +9050,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -9061,8 +9061,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.3.0-alpha"
-source = "git+https://github.com/iotaledger/iota#246f462c0bdf921a59c6df39a34559a9cf4eb95b"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#cb2eca765fe9d690934b7a40f5e47688dfb70e9f"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -39,11 +39,11 @@ docker volume rm iota-names-indexer_prometheus_data
 The following endpoints will be available:
 
 - **IOTA Names Indexer Metrics:** [http://localhost:9189/metrics](http://localhost:9189/metrics)
-- **REST API:** [http://localhost:3030](http://localhost:3030)
+- **Auction REST API:** [http://localhost:3030](http://localhost:3030)
 - **Prometheus:** [http://localhost:9090](http://localhost:9090)
 - **Grafana:** [http://localhost:3000](http://localhost:3000)
 
-## REST API Endpoints
+## Auction REST API Endpoints
 
 ### Health Check
 

--- a/indexer/docker/docker-compose.yml
+++ b/indexer/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: iota-names-indexer:dev
     ports:
       - "9189:9189/tcp" # Metrics
-      - 3030:3030 # Auction
+      - 3030:3030 # Auction REST API
     tty: true
     deploy:
       restart_policy:

--- a/indexer/docker/docker-compose.yml
+++ b/indexer/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: iota-names-indexer:dev
     ports:
       - "9189:9189/tcp" # Metrics
+      - 3030:3030 # Auction
     tty: true
     deploy:
       restart_policy:

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -66,7 +66,8 @@ impl IotaNamesExtendedConfig {
         const AUCTION_PACKAGE_ADDRESS: &str =
             "0x5e7a300e640f645a4030aeb507c7be16909e6fa9711e7ca2d4397bbd967d5c50";
         // TODO https://github.com/iotaledger/iota-names/issues/318
-        const COUPONS_PACKAGE_ADDRESS: &str = "0x";
+        const COUPONS_PACKAGE_ADDRESS: &str =
+            "0x0000000000000000000000000000000000000000000000000000000000000000";
         const SUBDOMAINS_PACKAGE_ADDRESS: &str =
             "0x2e541b250f53d45e9b4cb866be2ab3d8815015a249a094e63b196cc184278925";
         const AUCTION_HOUSE_ID: &str =

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -64,7 +64,7 @@ pub(crate) async fn run_iota_names_reader(
 
     info!("Connecting to node at {node_url}");
     // Localnet does not support remote store, so we use the REST API
-    if node_url == "http://localhost:9000" || node_url == "http://host.docker.internal:9000" {
+    if node_url.contains("localhost") || node_url.contains("host.docker.internal") {
         executor
             .run(
                 // path to a local directory where checkpoints are stored.

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -9,6 +9,7 @@ use diesel::Connection;
 use futures::FutureExt;
 use iota_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
+    reader::v2::{CheckpointReaderConfig, RemoteUrl},
 };
 use iota_json::IotaJsonValue;
 use iota_names::domain::Domain;
@@ -62,16 +63,28 @@ pub(crate) async fn run_iota_names_reader(
     executor.register(worker_pool).await?;
 
     info!("Connecting to node at {node_url}");
-    executor
-        .run(
-            // path to a local directory where checkpoints are stored.
-            PathBuf::from("./chk"),
-            Some(format!("{node_url}/api/v1")),
-            // optional remote store access options.
-            vec![],
-            ReaderOptions::default(),
-        )
-        .await?;
+    // Localnet does not support remote store, so we use the REST API
+    if node_url == "http://localhost:9000" || node_url == "http://host.docker.internal:9000" {
+        executor
+            .run(
+                // path to a local directory where checkpoints are stored.
+                PathBuf::from("./chk"),
+                Some(format!("{node_url}/api/v1")),
+                // optional remote store access options.
+                vec![],
+                ReaderOptions::default(),
+            )
+            .await?;
+    } else {
+        let config = CheckpointReaderConfig {
+            remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
+                historical_url: node_url.to_string(),
+                live_url: Some(format!("{node_url}/ingestion/live")),
+            }),
+            ..Default::default()
+        };
+        executor.run_with_config(config).await?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Make use of the indexer reader v2 with remote store, like `https://checkpoints.devnet.iota.cafe`
For localnets I kept the old version with REST API

To skip syncing the big genesis and all the checkpoints before we even published the package, the `progress_store` should be set to something like
```JSON
{
    "iota_names_reader": 67263904
}
```
where the checkpoint is just before the package was published

I changed the COUPONS_PACKAGE_ADDRESS because it would otherwise panic if no env values are provided
Also exposed the 3030 port for auctions

Fixes https://github.com/iotaledger/iota-names/issues/333

Tested with `RUST_LOG=debug,hyper_util=off cargo run start --node-url https://checkpoints.devnet.iota.cafe`
and `docker compose -f indexer/docker/docker-compose.yml up`