### PR TITLE
feat(iota-names): add admin_remove_records

### DIFF
--- a/packages/iota-names/sources/admin.move
+++ b/packages/iota-names/sources/admin.move
@@ -66,6 +66,7 @@ public fun admin_remove_records(
     mut domains: vector<String>,
 ) {
     let registry = iota_names::auth_registry_mut<AdminAuth, Registry>(AdminAuth {}, iota_names);
+    assert!(!domains.is_empty(), ENoDomainsProvided);
     while (!domains.is_empty()) {
         let domain = domain::new(domains.pop_back());
         registry.admin_force_remove_record(domain);

--- a/packages/iota-names/sources/admin.move
+++ b/packages/iota-names/sources/admin.move
@@ -52,3 +52,18 @@ entry fun reserve_domains(
         iota::transfer::public_transfer(nft, sender);
     };
 }
+
+/// Admin function to forcefully remove registry entries by their domain.
+/// This bypasses all expiration and authorization checks and immediately 
+/// removes the records and invalidates any reverse lookup entries.
+public fun admin_remove_records(
+    _: &AdminCap,
+    iota_names: &mut IotaNames,
+    mut domains: vector<String>,
+) {
+    let registry = iota_names::auth_registry_mut<AdminAuth, Registry>(AdminAuth {}, iota_names);
+    while (!domains.is_empty()) {
+        let domain = domain::new(domains.pop_back());
+        registry.admin_force_remove_record(domain);
+    };
+}

--- a/packages/iota-names/sources/admin.move
+++ b/packages/iota-names/sources/admin.move
@@ -69,6 +69,6 @@ public fun admin_remove_records(
     assert!(!domains.is_empty(), ENoDomainsProvided);
     while (!domains.is_empty()) {
         let domain = domain::new(domains.pop_back());
-        registry.admin_force_remove_record(domain);
+        registry.force_remove_record(domain);
     };
 }

--- a/packages/iota-names/sources/admin.move
+++ b/packages/iota-names/sources/admin.move
@@ -15,6 +15,9 @@ use iota_names::iota_names_registration::IotaNamesRegistration;
 use iota_names::registry::Registry;
 use std::string::String;
 
+#[error]
+const ENoDomainsProvided: vector<u8> = b"No domains provided";
+
 /// Authorization witness to call protected functions of `iota_names`.
 public struct AdminAuth has drop {}
 
@@ -45,6 +48,7 @@ entry fun reserve_domains(
     let sender = sender(ctx);
     let config = *iota_names.get_config<CoreConfig>();
     let registry = iota_names::auth_registry_mut<AdminAuth, Registry>(AdminAuth {}, iota_names);
+    assert!(!domains.is_empty(), ENoDomainsProvided);
     while (!domains.is_empty()) {
         let domain = domain::new(domains.pop_back());
         config.assert_is_valid_for_sale(&domain);

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -242,7 +242,7 @@ public fun remove_leaf_record(self: &mut Registry, domain: Domain) {
 /// Admin function to forcefully remove any record by domain.
 /// This bypasses all expiration and authorization checks.
 /// Should only be called by admin functions in the main module.
-public fun admin_force_remove_record(self: &mut Registry, domain: Domain) {
+public(package) fun admin_force_remove_record(self: &mut Registry, domain: Domain) {
     // Check if the record exists before trying to remove it
     if (!self.registry.contains(domain)) {
         return

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -239,10 +239,10 @@ public fun remove_leaf_record(self: &mut Registry, domain: Domain) {
     self.handle_invalidate_reverse_record(&domain, old_target_address, none());
 }
 
-/// Admin function to forcefully remove any record by domain.
+/// Forcefully remove any record by domain.
 /// This bypasses all expiration and authorization checks.
-/// Should only be called by admin functions in the main module.
-public(package) fun admin_force_remove_record(self: &mut Registry, domain: Domain) {
+/// Should only be called by admin functions.
+public(package) fun force_remove_record(self: &mut Registry, domain: Domain) {
     // Check if the record exists before trying to remove it
     if (!self.registry.contains(domain)) {
         return

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -239,6 +239,26 @@ public fun remove_leaf_record(self: &mut Registry, domain: Domain) {
     self.handle_invalidate_reverse_record(&domain, old_target_address, none());
 }
 
+/// Admin function to forcefully remove any record by domain.
+/// This bypasses all expiration and authorization checks.
+/// Should only be called by admin functions in the main module.
+public fun admin_force_remove_record(self: &mut Registry, domain: Domain) {
+    // Check if the record exists before trying to remove it
+    if (!self.registry.contains(domain)) {
+        return
+    };
+
+    event::emit(NameRecordRemovedEvent {
+        domain,
+    });
+    
+    let record = self.registry.remove(domain);
+    let old_target_address = record.target_address();
+
+    // Invalidate any reverse lookup entries
+    self.handle_invalidate_reverse_record(&domain, old_target_address, none());
+}
+
 public fun set_target_address(self: &mut Registry, domain: Domain, new_target: Option<address>) {
     let record = &mut self.registry[domain];
     let old_target = record.target_address();

--- a/packages/iota-names/tests/unit/admin_tests.move
+++ b/packages/iota-names/tests/unit/admin_tests.move
@@ -126,3 +126,196 @@ fun register_multiple() {
 
     scenario.end();
 }
+
+#[test]
+fun test_admin_remove_existing_records() {
+    let ctx = tx_context::dummy();
+    let mut scenario = iota::test_scenario::begin(ctx.sender());
+
+    {
+        let iota_names = iota_names::init_for_testing(scenario.ctx());
+        iota_names.share_for_testing();
+    };
+
+    let domains_to_register = vector[
+        utf8(b"domain1.iota"),
+        utf8(b"domain2.iota"),
+        utf8(b"domain3.iota"),
+    ];
+    
+    // Register the domains first
+    {
+        scenario.next_tx(ctx.sender());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+        let clock = clock::create_for_testing(scenario.ctx());
+        
+        registry::init_for_testing(&admin_cap, &mut iota_names, scenario.ctx());
+        iota_names::authorize_for_testing<AdminAuth>(&mut iota_names);
+
+        // Register domains
+        admin::reserve_domains(
+            &admin_cap,
+            &mut iota_names,
+            copy domains_to_register,
+            1,
+            &clock,
+            scenario.ctx()
+        );
+
+        clock.share_for_testing();
+        scenario.return_to_sender(admin_cap);
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Verify domains exist before removal
+    {
+        scenario.next_tx(ctx.sender());
+        let iota_names = scenario.take_shared<IotaNames>();
+        let registry = iota_names.registry<registry::Registry>();
+        
+        let mut i = 0;
+        while (i < domains_to_register.length()) {
+            let domain = domain::new(domains_to_register[i]);
+            assert!(registry.has_record(domain), 0);
+            i = i + 1;
+        };
+
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Remove the domains using admin_remove_records
+    {
+        scenario.next_tx(ctx.sender());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+
+        admin::admin_remove_records(
+            &admin_cap,
+            &mut iota_names,
+            domains_to_register,
+        );
+
+        scenario.return_to_sender(admin_cap);
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Verify domains are removed
+    {
+        scenario.next_tx(ctx.sender());
+        let iota_names = scenario.take_shared<IotaNames>();
+        let registry = iota_names.registry<registry::Registry>();
+        
+        let mut i = 0;
+        while (i < domains_to_register.length()) {
+            let domain = domain::new(domains_to_register[i]);
+            assert!(!registry.has_record(domain), 0);
+            i = i + 1;
+        };
+
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    scenario.end();
+}
+
+#[test]
+fun test_admin_remove_mixed_records() {
+    let ctx = tx_context::dummy();
+    let mut scenario = iota::test_scenario::begin(ctx.sender());
+
+    {
+        let iota_names = iota_names::init_for_testing(scenario.ctx());
+        iota_names.share_for_testing();
+    };
+
+    let existing_domains = vector[
+        utf8(b"existing1.iota"),
+        utf8(b"existing2.iota"),
+    ];
+    
+    let mixed_domains = vector[
+        utf8(b"existing1.iota"),
+        utf8(b"existing2.iota"),
+        utf8(b"nonexistent1.iota"),
+        utf8(b"nonexistent2.iota"),
+    ];
+    
+    // Register only some domains
+    {
+        scenario.next_tx(ctx.sender());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+        let clock = clock::create_for_testing(scenario.ctx());
+        
+        registry::init_for_testing(&admin_cap, &mut iota_names, scenario.ctx());
+        iota_names::authorize_for_testing<AdminAuth>(&mut iota_names);
+
+        admin::reserve_domains(
+            &admin_cap,
+            &mut iota_names,
+            copy existing_domains,
+            1,
+            &clock,
+            scenario.ctx()
+        );
+
+        clock.share_for_testing();
+        scenario.return_to_sender(admin_cap);
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Verify initial state - existing domains exist, non-existing don't
+    {
+        scenario.next_tx(ctx.sender());
+        let iota_names = scenario.take_shared<IotaNames>();
+        let registry = iota_names.registry<registry::Registry>();
+        
+        assert!(registry.has_record(domain::new(utf8(b"existing1.iota"))), 0);
+        assert!(registry.has_record(domain::new(utf8(b"existing2.iota"))), 0);
+        
+        assert!(!registry.has_record(domain::new(utf8(b"nonexistent1.iota"))), 0);
+        assert!(!registry.has_record(domain::new(utf8(b"nonexistent2.iota"))), 0);
+
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Remove mixed domains (existing and non-existing)
+    {
+        scenario.next_tx(ctx.sender());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+
+        // This should handle mixed domains gracefully - remove existing ones, ignore non-existing
+        admin::admin_remove_records(
+            &admin_cap,
+            &mut iota_names,
+            mixed_domains,
+        );
+
+        scenario.return_to_sender(admin_cap);
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    // Verify final state - all domains should be removed/not exist
+    {
+        scenario.next_tx(ctx.sender());
+        let iota_names = scenario.take_shared<IotaNames>();
+        let registry = iota_names.registry<registry::Registry>();
+        
+        let mut i = 0;
+        while (i < mixed_domains.length()) {
+            let domain = domain::new(mixed_domains[i]);
+            assert!(!registry.has_record(domain), 0);
+            i = i + 1;
+        };
+
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    scenario.end();
+}

--- a/packages/iota-names/tests/unit/admin_tests.move
+++ b/packages/iota-names/tests/unit/admin_tests.move
@@ -319,3 +319,41 @@ fun test_admin_remove_mixed_records() {
 
     scenario.end();
 }
+
+#[test, expected_failure(abort_code = ::iota_names::admin::ENoDomainsProvided)]
+fun test_reserve_domains_empty_list_fails() {
+    let ctx = tx_context::dummy();
+    let mut scenario = iota::test_scenario::begin(ctx.sender());
+
+    {
+        let iota_names = iota_names::init_for_testing(scenario.ctx());
+        iota_names.share_for_testing();
+    };
+
+    {
+        scenario.next_tx(ctx.sender());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+        let clock = clock::create_for_testing(scenario.ctx());
+        
+        registry::init_for_testing(&admin_cap, &mut iota_names, scenario.ctx());
+        iota_names::authorize_for_testing<AdminAuth>(&mut iota_names);
+
+        // Try to reserve an empty list of domains - this should fail
+        admin::reserve_domains(
+            &admin_cap,
+            &mut iota_names,
+            vector::empty<std::string::String>(),
+            1,
+            &clock,
+            scenario.ctx()
+        );
+
+        clock.share_for_testing();
+        scenario.return_to_sender(admin_cap);
+        iota::test_scenario::return_shared(iota_names);
+    };
+
+    scenario.end();
+}


### PR DESCRIPTION
Add a function for the admin to force remove records by their domain name

Can be used like this
```
ADMIN_CAP=0x03c2f9b2a3dbbfa50827a65b2003883e0d8d5c170d76166226faa99ecb58483b
IOTA_NAMES_PACKAGE_ID=0x921f4ce634cc7222b42aab7c2b16a2eb80128d3ac53fdff077c115f8f3d80fc7
IOTA_NAMES_OBJECT_ID=0x2e6a383f27cc9dfa05ef088b5a97b3d3e60bd3ee80d8d94f59eb6ece55c6e01c
DOMAIN_RECORDS_TO_REMOVE='["test.iota", "existing1.iota"]'
iota client ptb \
--make-move-vec "<std::string::String>" $DOMAIN_RECORDS_TO_REMOVE \
--assign domains_to_remove \
--move-call $IOTA_NAMES_PACKAGE_ID::admin::admin_remove_records @$ADMIN_CAP @$IOTA_NAMES_OBJECT_ID domains_to_remove \
--dry-run
```

Closes https://github.com/iotaledger/iota-names/issues/330