### PR TITLE
feat(dapp): fetch and display user auctions

### DIFF
--- a/dapp/.env.example
+++ b/dapp/.env.example
@@ -1,0 +1,2 @@
+# IOTA Names Indexer URL
+NEXT_PUBLIC_INDEXER_URL=http://localhost:3030

--- a/dapp/src/app/(protected)/my-names/page.tsx
+++ b/dapp/src/app/(protected)/my-names/page.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { AvailabilityCheck } from '@/components';
 import { UpdateNameDialog } from '@/components/dialogs/UpdateNameDialog';
 import { AvatarDisplay } from '@/components/name-record/AvatarDisplay';
+import { UserAuctions } from '@/components/UserAuctions';
 import { useRegistrationNfts } from '@/hooks';
 
 export default function MyNamesPage(): JSX.Element {
@@ -64,6 +65,9 @@ export default function MyNamesPage(): JSX.Element {
                     ))}
                 </div>
             )}
+            <div className="pt-md w-full max-w-md">
+                <UserAuctions />
+            </div>
         </div>
     );
 }

--- a/dapp/src/components/UserAuctions.tsx
+++ b/dapp/src/components/UserAuctions.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { useUserAuctions } from '@/hooks';
+
+export function UserAuctions() {
+    const { data: auctions, isLoading, error } = useUserAuctions();
+
+    if (isLoading) {
+        return (
+            <div className="rounded-lg border border-gray-200 p-6 dark:border-gray-700">
+                <h3 className="mb-4 text-lg font-semibold">My Auctions</h3>
+                <div className="animate-pulse space-y-2">
+                    <div className="h-4 bg-gray-200 rounded dark:bg-gray-700"></div>
+                    <div className="h-4 bg-gray-200 rounded dark:bg-gray-700"></div>
+                    <div className="h-4 bg-gray-200 rounded dark:bg-gray-700"></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="rounded-lg border border-red-200 p-6 dark:border-red-800">
+                <h3 className="mb-4 text-lg font-semibold">My Auctions</h3>
+                <p className="text-red-600 dark:text-red-400">
+                    Failed to load auctions. Please try again later.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-lg border border-gray-200 p-6 dark:border-gray-700">
+            <h3 className="mb-4 text-lg font-semibold">My Auctions</h3>
+            {!auctions || auctions.length === 0 ? (
+                <p className="text-gray-600 dark:text-gray-400">
+                    You haven't participated in any auctions yet.
+                </p>
+            ) : (
+                <div className="space-y-2">
+                    {auctions.map((domain) => (
+                        <div
+                            key={domain}
+                            className="flex items-center justify-between rounded-md bg-gray-50 p-3 dark:bg-gray-800"
+                        >
+                            <span className="font-medium">{domain}</span>
+                            <span className="text-sm text-gray-600 dark:text-gray-400">
+                                Auction participant
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/dapp/src/contexts/IotaNamesIndexerClientContext.tsx
+++ b/dapp/src/contexts/IotaNamesIndexerClientContext.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { IotaNamesIndexerClient } from '@/services/IotaNamesIndexerClient';
+
+export const IotaNamesIndexerClientContext = createContext<IotaNamesIndexerClient | null>(null);
+
+export interface IotaNamesIndexerClientProviderProps {
+    children: ReactNode;
+}
+
+export function IotaNamesIndexerClientProvider({ children }: IotaNamesIndexerClientProviderProps) {
+    const indexerUrl = process.env.NEXT_PUBLIC_INDEXER_URL;
+
+    const client = useMemo(() => {
+        if (!indexerUrl) {
+            console.warn('NEXT_PUBLIC_INDEXER_URL is not configured');
+
+            return null;
+        }
+        return new IotaNamesIndexerClient(indexerUrl);
+    }, [indexerUrl]);
+
+    return (
+        <IotaNamesIndexerClientContext.Provider value={client}>
+            {children}
+        </IotaNamesIndexerClientContext.Provider>
+    );
+}
+
+export function useIotaNamesIndexerClientContext(): IotaNamesIndexerClient | null {
+    const context = useContext(IotaNamesIndexerClientContext);
+    if (context === undefined) {
+        throw new Error(
+            'useIotaNamesIndexerClientContext must be used within an IotaNamesIndexerClientProvider',
+        );
+    }
+    return context;
+}

--- a/dapp/src/contexts/index.ts
+++ b/dapp/src/contexts/index.ts
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './IotaNamesClientContext';
+export * from './IotaNamesIndexerClientContext';
 export * from './ThemeContext';

--- a/dapp/src/hooks/index.ts
+++ b/dapp/src/hooks/index.ts
@@ -8,4 +8,5 @@ export * from './useRegisterNameTransaction';
 export * from './useRegistrationNfts';
 export * from './useTheme';
 export * from './usePriceList';
+export * from './useUserAuctions';
 export * from './queryKey';

--- a/dapp/src/hooks/queryKey.ts
+++ b/dapp/src/hooks/queryKey.ts
@@ -24,4 +24,7 @@ export const queryKey = {
 
     // Price List
     priceList: () => [queryKey.all, 'price-list'],
+
+    // Auctions indexer
+    userAuctionHistory: (address?: string) => [queryKey.all, 'user-auction-hist', address],
 };

--- a/dapp/src/hooks/useUserAuctions.ts
+++ b/dapp/src/hooks/useUserAuctions.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCurrentAccount } from '@iota/dapp-kit';
+import { useQuery } from '@tanstack/react-query';
+
+import { useIotaNamesIndexerClientContext } from '@/contexts';
+
+export function useUserAuctions() {
+    const account = useCurrentAccount();
+    const indexerClient = useIotaNamesIndexerClientContext();
+
+    return useQuery({
+        // eslint-disable-next-line @tanstack/query/exhaustive-deps
+        queryKey: ['user-auctions', account?.address],
+        queryFn: async () => {
+            if (!account?.address || !indexerClient) {
+                return [];
+            }
+
+            return indexerClient.getUserAuctions(account.address);
+        },
+        enabled: !!account?.address && !!indexerClient,
+    });
+}

--- a/dapp/src/hooks/useUserAuctions.ts
+++ b/dapp/src/hooks/useUserAuctions.ts
@@ -6,13 +6,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useIotaNamesIndexerClientContext } from '@/contexts';
 
+import { queryKey } from './queryKey';
+
 export function useUserAuctions() {
     const account = useCurrentAccount();
     const indexerClient = useIotaNamesIndexerClientContext();
 
     return useQuery({
         // eslint-disable-next-line @tanstack/query/exhaustive-deps
-        queryKey: ['user-auctions', account?.address],
+        queryKey: [...queryKey.userAuctionHistory(account?.address)],
         queryFn: async () => {
             if (!account?.address || !indexerClient) {
                 return [];

--- a/dapp/src/providers/AppProviders.tsx
+++ b/dapp/src/providers/AppProviders.tsx
@@ -8,7 +8,7 @@ import { getAllNetworks } from '@iota/iota-sdk/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { IotaNamesClientProvider } from '@/contexts';
+import { IotaNamesClientProvider, IotaNamesIndexerClientProvider } from '@/contexts';
 import { KioskClientProvider } from '@/contexts/KioskClientContext';
 import { createIotaClient } from '@/lib/utils/defaultRpcClient';
 
@@ -35,20 +35,22 @@ export function AppProviders({ children }: React.PropsWithChildren) {
             >
                 <KioskClientProvider>
                     <IotaNamesClientProvider>
-                        <WalletProvider
-                            autoConnect={true}
-                            theme={[
-                                {
-                                    variables: lightTheme,
-                                },
-                                {
-                                    selector: '.dark',
-                                    variables: darkTheme,
-                                },
-                            ]}
-                        >
-                            <ThemeProvider appId="IOTA-evm-bridge">{children}</ThemeProvider>
-                        </WalletProvider>
+                        <IotaNamesIndexerClientProvider>
+                            <WalletProvider
+                                autoConnect={true}
+                                theme={[
+                                    {
+                                        variables: lightTheme,
+                                    },
+                                    {
+                                        selector: '.dark',
+                                        variables: darkTheme,
+                                    },
+                                ]}
+                            >
+                                <ThemeProvider appId="IOTA-evm-bridge">{children}</ThemeProvider>
+                            </WalletProvider>
+                        </IotaNamesIndexerClientProvider>
                     </IotaNamesClientProvider>
                 </KioskClientProvider>
             </IotaClientProvider>

--- a/dapp/src/services/IotaNamesIndexerClient.ts
+++ b/dapp/src/services/IotaNamesIndexerClient.ts
@@ -5,7 +5,7 @@ export class IotaNamesIndexerClient {
     private host: string;
 
     constructor(host: string) {
-        this.host = host.endsWith('/') ? host.slice(0, -1) : host;
+        this.host = new URL(host).origin;
     }
 
     async getUserAuctions(address: string): Promise<string[]> {

--- a/dapp/src/services/IotaNamesIndexerClient.ts
+++ b/dapp/src/services/IotaNamesIndexerClient.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+export class IotaNamesIndexerClient {
+    private host: string;
+
+    constructor(host: string) {
+        this.host = host.endsWith('/') ? host.slice(0, -1) : host;
+    }
+
+    async getUserAuctions(address: string): Promise<string[]> {
+        const response = await fetch(`${this.host}/auctions/${address}`);
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch auctions: ${response.statusText}`);
+        }
+
+        return response.json();
+    }
+}


### PR DESCRIPTION
- Adds iota-names indexer context and client class
- Adds useUserAuctions hook
- Adds component to display user auctions

Closes https://github.com/iotaledger/iota-names/issues/307

⚠️ Testing on localnet with iota-names indexer:

- Build the indexer in docker: `docker compose -f indexer/docker/docker-compose.yml build --build-arg CACHEBUST=$(date +%s)` from root
- Run localnet
- With your `iota` CLI position to `env: localnet`
- Add funds to your currently active addres in `iota` CLI
- Deploy the iota-names Move contracts to localnet: `pnpm ts-node init/init.ts localnet` (from `scripts`)
- Copy the envs for indexer (from root): `cd scripts && pnpm ts-node utils/envs.ts localnet > ../indexer/docker/.env && cd ..`
- Copy (and adapt i.e. `paymentsPackageId`) the envs from `scripts/package-info/localnet.json` to `sdk/src/constants.ts`
- Run the indexer: `docker compose -f indexer/docker/docker-compose.yml up`
- Copy `dapp/.env.example` to `dapp/.env.local`
- Change the network in the dapp from `devnet` to `localnet`
- Run the `dapp`