### PR TITLE
fix(indexer): return empty array for an address without any auctions

### DIFF
--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -75,7 +75,14 @@ pub fn get_domains_for_bidder_address(
     let bidder = bidders::table
         .filter(bidders::address.eq(address))
         .select(Bidder::as_select())
-        .get_result(conn)?;
+        .get_result(conn)
+        .optional()?;
+
+    let bidder = match bidder {
+        Some(bidder) => bidder,
+        // Just return an empty vector if the bidder was not found
+        None => return Ok(vec![]),
+    };
 
     let domains = BidderDomain::belonging_to(&bidder)
         .inner_join(domains::table)


### PR DESCRIPTION
Return empty array for an address without any auctions

Fixes: https://github.com/iotaledger/iota-names/issues/348

Testd with `cargo run start` and then `curl http://localhost:3030/auctions/0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215` -> `[]`