### PR TITLE
fix(dapp): Use correct nft id to update avatar

### DIFF
--- a/dapp/src/components/dialogs/UpdateNameDialog.tsx
+++ b/dapp/src/components/dialogs/UpdateNameDialog.tsx
@@ -147,11 +147,7 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
     ) {
         // To edit the setup of a subdomain we need to get its parent
         // Its parent can be another name or another subdomain
-        const parentObjectId = getParentObjectId(
-            domainsOwned ?? [],
-            subdomainsOwned ?? [],
-            name,
-        );
+        const parentObjectId = getParentObjectId(domainsOwned ?? [], subdomainsOwned ?? [], name);
         if (parentObjectId) {
             updates.push({
                 type: 'edit-setup',

--- a/dapp/src/components/dialogs/UpdateNameDialog.tsx
+++ b/dapp/src/components/dialogs/UpdateNameDialog.tsx
@@ -164,7 +164,7 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
 
     if (avatarNftId && avatarNftId !== nameRecord?.nameRecord.avatar && nameRecord) {
         const nftId = isNameSubName
-            ? getSubdomainObjectId(subdomainsOwned ?? [], nameRecord.nameRecord.name)
+            ? getNameObject(domainsOwned ?? [], subdomainsOwned ?? [], nameRecord.nameRecord.name)
             : nameRecord.nameRecord.nftId;
         if (nftId) {
             updates.push({

--- a/dapp/src/components/dialogs/UpdateNameDialog.tsx
+++ b/dapp/src/components/dialogs/UpdateNameDialog.tsx
@@ -33,6 +33,7 @@ import { NameUpdate, useUpdateNameTransaction } from '@/hooks/useUpdateNameTrans
 import {
     getNamePermissions,
     getParentSubdomainObjectId,
+    getSubdomainObjectId,
     isNameRecordExpired,
 } from '@/lib/utils/names';
 
@@ -63,8 +64,8 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
         ? getNamePermissions(nameRecord.nameRecord)
         : null;
 
-    const domainsOwned = useRegistrationNfts('domain');
-    const subdomainsOwned = useRegistrationNfts('subdomain');
+    const { data: domainsOwned } = useRegistrationNfts('domain');
+    const { data: subdomainsOwned } = useRegistrationNfts('subdomain');
 
     const [isAvatarSelectorOpen, setIsAvatarSelectorOpen] = useState<boolean>(false);
     // Editable values
@@ -110,12 +111,17 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
 
     if (nameRecord && isThereAddress && isValidAddress && !isTargetUsedInName) {
         // Only allow changing the target address if it is valid and it is not used yet
-        updates.push({
-            type: 'set-target-address',
-            address: editTargetAddress,
-            isSubname: false,
-            nftId: nameRecord.nameRecord?.nftId || '',
-        });
+        const nftId = isNameSubName
+            ? getSubdomainObjectId(subdomainsOwned ?? [], nameRecord.nameRecord.name)
+            : nameRecord.nameRecord.nftId;
+        if (nftId) {
+            updates.push({
+                type: 'set-target-address',
+                address: editTargetAddress,
+                isSubname: !!isNameSubName,
+                nftId: nftId,
+            });
+        }
     }
 
     if (isDefaultName && !editIsDefaultName) {
@@ -138,8 +144,8 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
         // To edit the setup of a subdomain we need to get its parent
         // Its parent can be another name or another subdomain
         const parentObjectId = getParentSubdomainObjectId(
-            domainsOwned.data ?? [],
-            subdomainsOwned.data ?? [],
+            domainsOwned ?? [],
+            subdomainsOwned ?? [],
             name,
         );
         if (nameRecord && isNameSubName && parentObjectId) {
@@ -153,11 +159,17 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
         }
     }
 
-    if (avatarNftId && avatarNftId !== nameRecord?.nameRecord?.nftId) {
-        updates.push({
-            type: 'set-avatar',
-            nftId: avatarNftId,
-        });
+    if (avatarNftId && avatarNftId !== nameRecord?.nameRecord.avatar && nameRecord) {
+        const nftId = isNameSubName
+            ? getSubdomainObjectId(subdomainsOwned ?? [], nameRecord.nameRecord.name)
+            : nameRecord.nameRecord.nftId;
+        if (nftId) {
+            updates.push({
+                type: 'set-avatar',
+                nftId,
+                avatarNftId: avatarNftId,
+            });
+        }
     }
 
     const {
@@ -193,6 +205,7 @@ export function UpdateNameDialog({ name, open, setOpen }: UpdateNameDialogProps)
                             queryKey: queryKey.defaultName(account?.address || ''),
                         });
                         break;
+                    case 'set-avatar':
                     case 'edit-setup':
                     case 'set-target-address':
                         queryClient.invalidateQueries({

--- a/dapp/src/hooks/useUpdateNameTransaction.ts
+++ b/dapp/src/hooks/useUpdateNameTransaction.ts
@@ -21,6 +21,7 @@ export type NameUpdate =
     | {
           type: 'set-avatar';
           nftId: string;
+          avatarNftId: string;
       }
     | {
           type: 'set-target-address';
@@ -65,7 +66,7 @@ export function useUpdateNameTransaction({
                         iotaNamesTx.setUserData({
                             nft: update.nftId,
                             key: ALLOWED_METADATA.avatar,
-                            value: update.nftId,
+                            value: update.avatarNftId,
                         });
                         break;
                     case 'set-target-address':

--- a/dapp/src/lib/utils/names.ts
+++ b/dapp/src/lib/utils/names.ts
@@ -43,3 +43,13 @@ export function getParentSubdomainObjectId(
     const parent = parentNames.find(({ name }) => name === parentName);
     return parent?.id || null;
 }
+
+/**
+ * Get object id of a given subdomain
+ */
+export function getSubdomainObjectId(ownedSubdomains: RegistrationNft[], name: string) {
+    const subdomain = ownedSubdomains.find(
+        (subdomain: { name: string | null }) => subdomain.name === name,
+    );
+    return subdomain?.id || null;
+}


### PR DESCRIPTION
- use actual name id to update the avatar
- adds support to update avatar in subnames
- adds missing query invalidation after setting the avatar