### PR TITLE
fix(scripts): rename `IOTA_NAMES_SUBDOMAINS_PACKAGE_ADDRESS`

### DIFF
--- a/scripts/utils/envs.ts
+++ b/scripts/utils/envs.ts
@@ -30,7 +30,7 @@ const envVars = {
     IOTA_NAMES_REVERSE_REGISTRY_ID: json.reverseRegistryTableId,
     IOTA_NAMES_AUCTION_PACKAGE_ADDRESS: json.auctionPackageId,
     IOTA_NAMES_COUPONS_PACKAGE_ADDRESS: json.couponsPackageId,
-    IOTA_NAMES_SUBDOMAINS_PACKAGE_ADDRESS: json.subNamesPackageId,
+    IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS: json.subNamesPackageId,
     IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID: json.auctionHouseObjectId,
 };
 


### PR DESCRIPTION
```bash
WARN[0000] The "IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS" variable is not set. Defaulting to a blank string. 
```