### PR TITLE
chore(*): Improve coverage

### DIFF
--- a/packages/iota-names/tests/controller_tests.move
+++ b/packages/iota-names/tests/controller_tests.move
@@ -464,6 +464,17 @@ fun test_set_user_data() {
     assert_eq(*data.get(&DATA_KEY_AVATAR.to_string()), b"value_avatar".to_string());
     assert_eq(*data.get(&utf8(DATA_KEY_IPFS)), b"value_ipfs".to_string());
 
+    set_user_data_util(
+        scenario,
+        FIRST_ADDRESS,
+        DATA_KEY_AVATAR.to_string(),
+        b"value_new_avatar".to_string(),
+        0,
+    );
+    let data = &scenario.get_user_data(NAME.to_string());
+    assert_eq(data.size(), 2);
+    assert_eq(*data.get(&DATA_KEY_AVATAR.to_string()), b"value_new_avatar".to_string());
+
     scenario_val.end();
 }
 

--- a/packages/subnames/tests/unit_tests.move
+++ b/packages/subnames/tests/unit_tests.move
@@ -8,7 +8,7 @@ module iota_names_subnames::unit_tests;
 
 use iota_names::name::{Self, new as new_name, parent};
 use std::string::utf8;
-use iota_names_subnames::config::{assert_is_valid_subname, default};
+use iota_names_subnames::config::{assert_is_valid_subname, default, new};
 
 // === Validity of subname | parent lengths (based on string) ===
 #[test]
@@ -105,7 +105,7 @@ fun test_invalid_parent_sln_failure() {
 fun test_invalid_child_label_size_failure() {
     assert_is_valid_subname(
         &new_name(utf8(b"sub.test.iota")),
-        &new_name(utf8(b"ob.example.iota")),
+        &new_name(utf8(b"ob.test.iota")),
         &default(),
     );
 }
@@ -113,8 +113,8 @@ fun test_invalid_child_label_size_failure() {
 #[test, expected_failure(abort_code = iota_names_subnames::config::ENotSupportedTLN)]
 fun test_not_supported_tln_failure() {
     assert_is_valid_subname(
-        &new_name(utf8(b"sub.sub.example.move")),
         &new_name(utf8(b"sub.example.move")),
+        &new_name(utf8(b"sub.sub.example.move")),
         &default(),
     );
 }
@@ -138,5 +138,14 @@ fun derive_parent_from_child() {
                 b"sub.sub.sub.sub.sub.example.iota"
             ),
         0,
+    );
+}
+
+#[test]
+fun test_custom_config() {
+    assert_is_valid_subname(
+        &new_name(utf8(b"a.move")),
+        &new_name(utf8(b"b.a.move")),
+        &new(vector[b"iota".to_string(), b"move".to_string()], 3, 1, 60 * 60 * 1000),
     );
 }

--- a/packages/subnames/tests/unit_tests.move
+++ b/packages/subnames/tests/unit_tests.move
@@ -8,7 +8,7 @@ module iota_names_subnames::unit_tests;
 
 use iota_names::name::{Self, new as new_name, parent};
 use std::string::utf8;
-use iota_names_subnames::config::{assert_is_valid_subname, default, new};
+use iota_names_subnames::config::{assert_is_valid_subname, default, new as new_config};
 
 // === Validity of subname | parent lengths (based on string) ===
 #[test]
@@ -146,6 +146,6 @@ fun test_custom_config() {
     assert_is_valid_subname(
         &new_name(utf8(b"a.move")),
         &new_name(utf8(b"b.a.move")),
-        &new(vector[b"iota".to_string(), b"move".to_string()], 3, 1, 60 * 60 * 1000),
+        &new_config(vector[b"move".to_string()], 3, 1, 60 * 60 * 1000),
     );
 }


### PR DESCRIPTION
Improves code coverage of various modules:
- `iota_names::controller` : 100%
- `subdomain::config`: 100%
https://github.com/iotaledger/iota-names/issues/175