### PR TITLE
fix(sdk): Fix imports

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,7 +4,7 @@
 
 export { IotaNamesClient } from './iota-names-client.js';
 export { IotaNamesTransaction } from './iota-names-transaction.js';
-export type { IotaNamesClientConfig, NameRecord } from './types';
+export type { IotaNamesClientConfig, NameRecord } from './types.js';
 export { ALLOWED_METADATA, MIN_LABEL_SIZE, GRACE_PERIOD_MS, packages } from './constants.js';
 export {
     isSubname,
@@ -16,5 +16,5 @@ export {
     getRenewalPricelistConfigType,
     getNameRegistrationType,
     getSubnameRegistrationType,
-} from './helpers';
-export { isValidIotaName, validateIotaName, normalizeIotaName } from './utils';
+} from './helpers.js';
+export { isValidIotaName, validateIotaName, normalizeIotaName } from './utils.js';

--- a/sdk/src/iota-names-transaction.ts
+++ b/sdk/src/iota-names-transaction.ts
@@ -13,7 +13,7 @@ import { IOTA_CLOCK_OBJECT_ID } from '@iota/iota-sdk/utils';
 import { ALLOWED_METADATA } from './constants.js';
 import { isNestedSubname, isSubname } from './helpers.js';
 import type { IotaNamesClient } from './iota-names-client.js';
-import type { ReceiptParams, RegistrationParams, RenewalParams } from './types';
+import type { ReceiptParams, RegistrationParams, RenewalParams } from './types.js';
 import { isValidIotaName, normalizeIotaName } from './utils.js';
 
 export class IotaNamesTransaction {


### PR DESCRIPTION
When using the SDK in the monorepo apps, there are errors if the imports are not `.js`