### PR TITLE
feat(packages): increase test coverage, remove unused code

### DIFF
--- a/packages/coupons/sources/coupon_house.move
+++ b/packages/coupons/sources/coupon_house.move
@@ -269,14 +269,6 @@ fun assert_is_authorized<A: drop>(coupon_house: &CouponHouse) {
     assert!(coupon_house.is_authorized<A>(), EAppNotAuthorized);
 }
 
-public(package) fun coupons(coupon_house: &CouponHouse): &Coupons {
-    &coupon_house.coupons
-}
-
-public(package) fun coupons_mut(coupon_house: &mut CouponHouse): &mut Coupons {
-    &mut coupon_house.coupons
-}
-
 public(package) fun coupons_table(coupon_house: &CouponHouse): &Table<vector<u8>, Coupon> {
     coupon_house.coupons.coupons()
 }

--- a/packages/coupons/tests/authorization_tests.move
+++ b/packages/coupons/tests/authorization_tests.move
@@ -34,17 +34,17 @@ fun deauthorize_success() {
     {
         scenario.next_tx(admin());
 
-        let mut coupon_house = scenario.take_shared();
+        let mut iota_names = scenario.take_shared();
         let admin_cap = scenario.take_from_sender();
 
         // test app deauthorization.
-        deauthorize<TestAuth>(&admin_cap, &mut coupon_house);
+        deauthorize<TestAuth>(&admin_cap, &mut iota_names);
 
         // test that the app is indeed non authorized
-        assert!(!coupon_house.is_authorized<TestAuth>(), 0);
+        assert!(!iota_names.is_authorized<TestAuth>(), 0);
 
         return_to_sender(scenario, admin_cap);
-        return_shared(coupon_house);
+        return_shared(iota_names);
     };
     end(scenario_val);
 }

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -8,9 +8,9 @@ module iota_names_coupons::coupon_tests;
 use iota::clock::Clock;
 use iota::hash::blake2b256;
 use iota::hex;
-use iota::test_scenario::{Scenario, return_shared};
+use iota::test_scenario::{Scenario, end, return_shared, return_to_sender};
 use iota::test_utils::{Self, destroy};
-use iota_names::iota_names::IotaNames;
+use iota_names::iota_names::{IotaNames, AdminCap};
 use iota_names::name_registration::NameRegistration;
 use iota_names::payment::PaymentIntent;
 use iota_names_coupons::coupon_house;
@@ -24,6 +24,7 @@ use iota_names_coupons::setup::{
     user,
     user_two,
     test_app,
+    admin,
     admin_add_percentage_coupon,
     admin_add_fixed_coupon,
     test_init,
@@ -336,6 +337,32 @@ fun max_years_two_failure() {
         option::none(),
         option::none(),
         option::some(range::new(5, 4)),
+        false,
+    );
+}
+
+#[test, expected_failure(abort_code = ::iota_names_coupons::rules::ENoMoreAvailableClaims)]
+fun decrease_until_no_more_available_claims() {
+    let mut coupon_rules = rules::new_coupon_rules(
+        option::none(),
+        option::some(1),
+        option::none(),
+        option::none(),
+        option::none(),
+        false,
+    );
+    rules::decrease_available_claims(&mut coupon_rules);
+    rules::decrease_available_claims(&mut coupon_rules);
+}
+
+#[test, expected_failure(abort_code = ::iota_names_coupons::rules::EInvalidAvailableClaims)]
+fun create_no_available_claims() {
+    rules::new_coupon_rules(
+        option::none(),
+        option::some(0),
+        option::none(),
+        option::none(),
+        option::none(),
         false,
     );
 }
@@ -676,4 +703,25 @@ fun test_coupon_getters() {
     // Test discount getter
     assert!(coupon::discount(&percentage_coupon) == 25);
     assert!(coupon::discount(&fixed_coupon) == 1000);
+}
+
+#[test, expected_failure(abort_code = ::iota_names_coupons::coupon_house::EInvalidVersion)]
+fun test_admin_set_version() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(admin());
+
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+
+        coupon_house::set_version(&admin_cap, &mut iota_names, 2);
+
+        let coupon_house = iota_names.registry<coupon_house::CouponHouse>();
+        coupon_house.assert_version_is_valid();
+
+        return_to_sender(scenario, admin_cap);
+        return_shared(iota_names);
+    };
+    end(scenario_val);
 }

--- a/packages/iota-names/sources/name.move
+++ b/packages/iota-names/sources/name.move
@@ -129,13 +129,10 @@ public fun parent(name: &Name): Option<Name> {
 /// e.g. (`example.iota`, `subname.example.iota`) -> `true`
 public fun is_parent_of(parent: &Name, child: &Name): bool {
     if (number_of_levels(parent) < number_of_levels(child)) {
-        let mut maybe_parent = parent(child);
-        if (maybe_parent.is_some()) {
-            let parent_name = maybe_parent.extract();
-            parent_name.labels == &parent.labels
-        } else {
-            false
-        }
+        // This is safe to extract, because `parent` is guaranteed to be a valid name with 2 labels,
+        // so `child` will always have at least 3 labels here and thus always has a parent.
+        let parent_name = parent(child).extract();
+        parent_name.labels == &parent.labels
     } else {
         false
     }
@@ -432,6 +429,11 @@ fun test_validate_labels_too_long() {
 #[test, expected_failure(abort_code = ::iota_names::name::EInvalidName)]
 fun test_validate_labels_too_short() {
     new(utf8(b".iota"));
+}
+
+#[test, expected_failure(abort_code = ::iota_names::name::EInvalidName)]
+fun test_validate_name_too_long() {
+    new(utf8(b"236chars-is-one-too-much-236chars-is-one-too-much.236chars-is-one-too-much-236chars-is-one-too-much.236chars-is-one-too-much-236chars-is-one-too-much.236chars-is-one-too-much-236chars-is-one-too-much.236chars-is-one-too-much-236cha.iota"));
 }
 
 #[test]

--- a/packages/iota-names/tests/payments/payment_tests.move
+++ b/packages/iota-names/tests/payments/payment_tests.move
@@ -195,6 +195,31 @@ fun try_to_renew_subname() {
     abort 1337
 }
 
+#[test]
+fun test_renew_data_mut() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+    let clock = clock::create_for_testing(&mut ctx);
+
+    // Register a name
+    let name = b"test.iota".to_string();
+    let intent = payment::init_registration(
+        &mut iota_names,
+        name,
+    );
+    let receipt = handle_payment(intent, &mut iota_names, &mut ctx);
+    let nft = receipt.register(&mut iota_names, &clock, &mut ctx);
+
+    // Start renewal process so we can test request_data_mut()
+    let mut intent = payment::init_renewal(&mut iota_names, &nft, 1);
+    let _request_data_mut = intent.request_data_mut(&iota_names, PaymentsAuth {});
+
+    destroy(intent);
+    destroy(iota_names);
+    destroy(nft);
+    destroy(clock);
+}
+
 #[test, expected_failure(abort_code = ::iota_names::payment::ERecordExpired)]
 fun try_renewing_expired_name() {
     let mut ctx = tx_context::dummy();


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-names/issues/175

`iota move test --coverage && iota move coverage summary`
```
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000000::range
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::rules
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::coupon
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::coupons
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::coupon_house
>>> % Module coverage: 100.00
+-------------------------+
| % Move Coverage: 100.00  |
+-------------------------+

+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000000::name
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::constants
>>> % Module coverage: 60.00 (doesn't really make sense to test)
Module 0000000000000000000000000000000000000000000000000000000000000000::name_registration
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::subname_registration
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::name_record
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::iota_names
>>> % Module coverage: 90.26 (package init function, can't be tested)
Module 0000000000000000000000000000000000000000000000000000000000000000::registry
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::core_config
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::admin
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::controller
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::deny_list
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::validation
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::pricing_config
>>> % Module coverage: 100.00
Module 0000000000000000000000000000000000000000000000000000000000000000::payment
>>> % Module coverage: 100.00
+-------------------------+
| % Move Coverage: 99.16  |
+-------------------------+

```
