### PR TITLE
fix(indexer): Add `temp-subname-proxy` package to IOTA-Names package list

### DIFF
--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -16,6 +16,8 @@ pub struct IotaNamesExtendedConfig {
     pub coupons_package_address: IotaAddress,
     /// Address of the `subnames` package.
     pub subnames_package_address: IotaAddress,
+    /// Address of the `temp-subname-proxy` package
+    pub subname_proxy_package_address: IotaAddress,
     /// ID of the `AuctionHouse` object.
     pub auction_house_id: ObjectID,
     pub iota_names_config: IotaNamesConfig,
@@ -34,6 +36,7 @@ impl IotaNamesExtendedConfig {
         auction_package_address: IotaAddress,
         coupons_package_address: IotaAddress,
         subnames_package_address: IotaAddress,
+        subname_proxy_package_address: IotaAddress,
         auction_house_id: ObjectID,
         iota_names_config: IotaNamesConfig,
     ) -> Self {
@@ -41,6 +44,7 @@ impl IotaNamesExtendedConfig {
             auction_package_address,
             coupons_package_address,
             subnames_package_address,
+            subname_proxy_package_address,
             auction_house_id,
             iota_names_config,
         }
@@ -53,6 +57,7 @@ impl IotaNamesExtendedConfig {
             std::env::var("IOTA_NAMES_AUCTION_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_COUPONS_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS")?.parse()?,
+            std::env::var("IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID")?.parse()?,
             iota_names_config,
         ))
@@ -69,18 +74,23 @@ impl IotaNamesExtendedConfig {
             "0xf2d61106ef44216f03709276c4e79c78485080c6d8fbad8464b7a570b9f36470";
         const SUBNAMES_PACKAGE_ADDRESS: &str =
             "0x1efbf928710d0d92635dacff4c502516169d37fa006cabd2f3cdd0123221e09e";
+        const TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS: &str =
+            "0x4a16b7b2a9c194989519c87ee3f1d1007ece8aecb62b9a50a4c10075db0591a3";
         const AUCTION_HOUSE_ID: &str =
             "0xc922c77a1d4f4e699aa912a7c24aee4668f8975d2a5f01ba780f656289bf2c2c";
 
         let auction_package_address = IotaAddress::from_str(AUCTION_PACKAGE_ADDRESS).unwrap();
         let coupons_package_address = IotaAddress::from_str(COUPONS_PACKAGE_ADDRESS).unwrap();
         let subnames_package_address = IotaAddress::from_str(SUBNAMES_PACKAGE_ADDRESS).unwrap();
+        let subname_proxy_package_address =
+            IotaAddress::from_str(TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS).unwrap();
         let auction_house_id = ObjectID::from_str(AUCTION_HOUSE_ID).unwrap();
 
         Self::new(
             auction_package_address,
             coupons_package_address,
             subnames_package_address,
+            subname_proxy_package_address,
             auction_house_id,
             IotaNamesConfig::devnet(),
         )
@@ -88,12 +98,14 @@ impl IotaNamesExtendedConfig {
 
     /// Checks whether the given package address is an IOTA-Names one.
     pub fn is_iota_names_package(&self, package_address: impl Into<IotaAddress>) -> bool {
-        let package_address = package_address.into();
-
-        package_address == self.auction_package_address
-            || package_address == self.coupons_package_address
-            || package_address == self.iota_names_config.package_address
-            || package_address == self.iota_names_config.payments_package_address
-            || package_address == self.subnames_package_address
+        [
+            self.auction_package_address,
+            self.coupons_package_address,
+            self.iota_names_config.package_address,
+            self.iota_names_config.payments_package_address,
+            self.subnames_package_address,
+            self.subname_proxy_package_address,
+        ]
+        .contains(&package_address.into())
     }
 }

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -98,14 +98,13 @@ impl IotaNamesExtendedConfig {
 
     /// Checks whether the given package address is an IOTA-Names one.
     pub fn is_iota_names_package(&self, package_address: impl Into<IotaAddress>) -> bool {
-        [
-            self.auction_package_address,
-            self.coupons_package_address,
-            self.iota_names_config.package_address,
-            self.iota_names_config.payments_package_address,
-            self.subnames_package_address,
-            self.subname_proxy_package_address,
-        ]
-        .contains(&package_address.into())
+        let package_address = package_address.into();
+
+        package_address == self.auction_package_address
+            || package_address == self.coupons_package_address
+            || package_address == self.iota_names_config.package_address
+            || package_address == self.iota_names_config.payments_package_address
+            || package_address == self.subnames_package_address
+            || package_address == self.subname_proxy_package_address
     }
 }

--- a/scripts/utils/envs.ts
+++ b/scripts/utils/envs.ts
@@ -31,6 +31,7 @@ const envVars = {
     IOTA_NAMES_AUCTION_PACKAGE_ADDRESS: json.auctionPackageId,
     IOTA_NAMES_COUPONS_PACKAGE_ADDRESS: json.couponsPackageId,
     IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS: json.subnamesPackageId,
+    IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS: json.tempSubnameProxyPackageId,
     IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID: json.auctionHouseObjectId,
 };
 


### PR DESCRIPTION
## Description

Adds the `temp-subname-proxy` package to the list of valid IOTA-Names packages and exports it in the util envs script.

Fixes an issue where subnames were not included in the following graph:

<img width="398" height="227" alt="image" src="https://github.com/user-attachments/assets/39422012-98ff-4e97-8c9b-2da609851e2d" />
