### PR TITLE
fix(scripts): validate labels and names before publish, split label txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All in one:
 ```bash
 docker start postgres || docker run -d --name postgres -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_INITDB_ARGS="-U postgres" -p 5432:5432 postgres:15 -c max_connections=1000
 # Run network in the background without logs
-iota start --force-regenesis --with-faucet --committee-size 2 --with-indexer --with-graphql > /dev/null 2>&1 &
+iota start --force-regenesis --with-faucet --committee-size 1 --with-indexer --with-graphql > /dev/null 2>&1 &
 iota client new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:9125
 iota client switch --env localnet
 # wait for the network to start

--- a/scripts/init/init.ts
+++ b/scripts/init/init.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
 import { readPackageInfo, writePackageInfo } from '../package-info/constants';
-import { hasLabelFilesToProcess, processLabelFiles } from '../reserved-names/deny-labels';
+import { parseLabelsFile, processLabelsFileBatched } from '../reserved-names/deny-labels';
 import { parseCsvFile, registerNames } from '../reserved-names/register-names';
 import { getClient, getIotaNamesAdminObjects, signAndExecute } from '../utils/utils';
 import { publishPackages } from './publish';
@@ -28,6 +28,8 @@ export const init = async (
     newOwner: string | undefined,
     isCIJob: boolean,
 ) => {
+    // Validate label and name files before proceeding
+    validateLabelAndNameFiles();
     if (!network) {
         throw new Error(
             '`network` not defined. Please run `pnpm ts-node init.ts <network>` (e.g., mainnet, testnet, devnet, localnet)',
@@ -41,6 +43,23 @@ export const init = async (
     const client = getClient(network);
     const packageInfo = readPackageInfo(network);
 
+    // Blocked and reserved labels (batched)
+    await processLabelsFileBatched(
+        './init/labels-to-block.txt',
+        'block',
+        packageInfo,
+        network,
+        client,
+    );
+    await processLabelsFileBatched(
+        './init/labels-to-reserve.txt',
+        'reserve',
+        packageInfo,
+        network,
+        client,
+    );
+
+    // Register names
     let namesToRegisterFile = './init/names-to-register.csv';
     if (fs.existsSync(namesToRegisterFile)) {
         const nameAddressPairs = parseCsvFile(namesToRegisterFile);
@@ -64,24 +83,6 @@ export const init = async (
         }
     }
 
-    if (hasLabelFilesToProcess()) {
-        const tx = new Transaction();
-        const hasChanges = processLabelFiles(
-            tx,
-            packageInfo.packageId,
-            packageInfo.iotaNamesObjectId,
-            packageInfo.adminCap,
-        );
-
-        if (hasChanges) {
-            const result = await signAndExecute(tx, network);
-            await client.waitForTransaction({ digest: result.digest });
-            console.log(`Transaction digest: ${result.digest}`);
-        } else {
-            console.log('No labels provided to reserve or block');
-        }
-    }
-
     if (!newOwner) {
         return;
     }
@@ -98,5 +99,36 @@ export const init = async (
     packageInfo.adminAddress = newOwner;
     writePackageInfo(network, packageInfo);
 };
+
+// Validate label and name files for invalid entries
+function validateLabelAndNameFiles() {
+    // Validate blocked labels
+    try {
+        parseLabelsFile('./init/labels-to-block.txt');
+    } catch (e) {
+        throw new Error(
+            `Blocked labels file contains invalid label(s): ${e instanceof Error ? e.message : e}`,
+        );
+    }
+    // Validate reserved labels
+    try {
+        parseLabelsFile('./init/labels-to-reserve.txt');
+    } catch (e) {
+        throw new Error(
+            `Reserved labels file contains invalid label(s): ${e instanceof Error ? e.message : e}`,
+        );
+    }
+    // Validate names to register
+    const namesToRegisterFile = './init/names-to-register.csv';
+    if (fs.existsSync(namesToRegisterFile)) {
+        try {
+            parseCsvFile(namesToRegisterFile);
+        } catch (e) {
+            throw new Error(
+                `Names to register file contains invalid entry: ${e instanceof Error ? e.message : e}`,
+            );
+        }
+    }
+}
 
 init(network, newOwner, !!process.env.IS_CI_JOB);

--- a/scripts/reserved-names/deny-labels.ts
+++ b/scripts/reserved-names/deny-labels.ts
@@ -117,12 +117,7 @@ export async function processLabelsFileBatched(
     for (const label of allLabels) {
         const labelLen = label.length + (batch.length > 0 ? 1 : 0);
         if (batchLen + labelLen > PURE_ARG_SIZE_LIMIT) {
-            const tx = new Transaction();
-            console.log(`${action === 'block' ? 'Blocking' : 'Reserving'} ${batch.length} labels`);
-            processLabelsBatch(tx, packageInfo, action, batch);
-            const result = await signAndExecute(tx, network);
-            await client.waitForTransaction({ digest: result.digest });
-            console.log(`Transaction digest: ${result.digest}`);
+            await sendLabelsBatchTransaction(batch, action, packageInfo, network, client);
             batch = [];
             batchLen = 0;
         }
@@ -130,11 +125,21 @@ export async function processLabelsFileBatched(
         batchLen += labelLen;
     }
     if (batch.length > 0) {
-        const tx = new Transaction();
-        console.log(`${action === 'block' ? 'Blocking' : 'Reserving'} ${batch.length} labels`);
-        processLabelsBatch(tx, packageInfo, action, batch);
-        const result = await signAndExecute(tx, network);
-        await client.waitForTransaction({ digest: result.digest });
-        console.log(`Transaction digest: ${result.digest}`);
+        await sendLabelsBatchTransaction(batch, action, packageInfo, network, client);
     }
+}
+
+async function sendLabelsBatchTransaction(
+    batch: string[],
+    action: 'block' | 'reserve',
+    packageInfo: PackageInfoForLabels,
+    network: string,
+    client: any,
+) {
+    const tx = new Transaction();
+    console.log(`${action === 'block' ? 'Blocking' : 'Reserving'} ${batch.length} labels`);
+    processLabelsBatch(tx, packageInfo, action, batch);
+    const result = await signAndExecute(tx, network);
+    await client.waitForTransaction({ digest: result.digest });
+    console.log(`Transaction digest: ${result.digest}`);
 }

--- a/scripts/reserved-names/deny-labels.ts
+++ b/scripts/reserved-names/deny-labels.ts
@@ -4,23 +4,33 @@
 import fs from 'fs';
 import { Transaction } from '@iota/iota-sdk/transactions';
 
+import { signAndExecute } from '../utils/utils';
+
+// Arg size needs to be limited to not exceed protocol limits
+const PURE_ARG_SIZE_LIMIT = 10000;
 const LABEL_REGEX = /(?!-)[a-z0-9-]{0,62}[a-z0-9]/;
 
 // Parses a text file with comma-separated labels
-export const parseTextFile = (filePath: string): string[] => {
+export const parseLabelsFile = (filePath: string): string[] => {
     const fileContent = fs.readFileSync(filePath, 'utf8').trim();
 
     if (!fileContent) {
         return [];
     }
 
+    // Convert to lowercase, trim, and remove duplicates
+    const seen = new Set<string>();
     return fileContent
         .split(',')
-        .map((label) => label.trim())
+        .map((label) => label.trim().toLowerCase())
         .filter((label) => {
             if (!LABEL_REGEX.test(label)) {
                 throw new Error(`Invalid label provided: "${label}"`);
             }
+            if (seen.has(label)) {
+                return false;
+            }
+            seen.add(label);
             return true;
         });
 };
@@ -59,37 +69,72 @@ export const addReservedLabels = (
     });
 };
 
-// Check if any label files exist
-export const hasLabelFilesToProcess = (): boolean => {
-    const files = ['./init/labels-to-block.txt', './init/labels-to-reserve.txt'];
-
-    return files.some((path) => fs.existsSync(path));
-};
-
-// Reserve and block labels from files if provided
-export const processLabelFiles = (
-    tx: Transaction,
-    packageId: string,
-    iotaNamesObjectId: string,
-    adminCap: string,
-): boolean => {
-    const files = [
-        { path: './init/labels-to-block.txt', action: 'Blocking', fn: addBlockedLabels },
-        { path: './init/labels-to-reserve.txt', action: 'Reserving', fn: addReservedLabels },
-    ];
-
-    let hasLabels = false;
-
-    for (const { path, action, fn } of files) {
-        if (fs.existsSync(path)) {
-            const labels = parseTextFile(path);
-            if (labels.length > 0) {
-                console.log(`${action} ${labels.length} labels`);
-                fn(tx, packageId, iotaNamesObjectId, adminCap, labels);
-                hasLabels = true;
-            }
-        }
+// Check if a label file exists and has at least one valid label
+export const hasLabelsInFile = (filePath: string): boolean => {
+    if (!fs.existsSync(filePath)) return false;
+    try {
+        const labels = parseLabelsFile(filePath);
+        return labels.length > 0;
+    } catch {
+        return false;
     }
-
-    return hasLabels;
 };
+
+// Type for package info
+export type PackageInfoForLabels = {
+    packageId: string;
+    iotaNamesObjectId: string;
+    adminCap: string;
+};
+
+// Process a batch of labels for blocking or reserving
+export function processLabelsBatch(
+    tx: Transaction,
+    packageInfo: PackageInfoForLabels,
+    action: 'block' | 'reserve',
+    labels: string[],
+): void {
+    const { packageId, iotaNamesObjectId, adminCap } = packageInfo;
+    if (action === 'block') {
+        addBlockedLabels(tx, packageId, iotaNamesObjectId, adminCap, labels);
+    } else {
+        addReservedLabels(tx, packageId, iotaNamesObjectId, adminCap, labels);
+    }
+}
+
+// Shared function to batch and process labels from a file
+export async function processLabelsFileBatched(
+    filePath: string,
+    action: 'block' | 'reserve',
+    packageInfo: PackageInfoForLabels,
+    network: string,
+    client: any,
+): Promise<void> {
+    if (!hasLabelsInFile(filePath)) return;
+    const allLabels = parseLabelsFile(filePath);
+    let batch: string[] = [];
+    let batchLen = 0;
+    for (const label of allLabels) {
+        const labelLen = label.length + (batch.length > 0 ? 1 : 0);
+        if (batchLen + labelLen > PURE_ARG_SIZE_LIMIT) {
+            const tx = new Transaction();
+            console.log(`${action === 'block' ? 'Blocking' : 'Reserving'} ${batch.length} labels`);
+            processLabelsBatch(tx, packageInfo, action, batch);
+            const result = await signAndExecute(tx, network);
+            await client.waitForTransaction({ digest: result.digest });
+            console.log(`Transaction digest: ${result.digest}`);
+            batch = [];
+            batchLen = 0;
+        }
+        batch.push(label);
+        batchLen += labelLen;
+    }
+    if (batch.length > 0) {
+        const tx = new Transaction();
+        console.log(`${action === 'block' ? 'Blocking' : 'Reserving'} ${batch.length} labels`);
+        processLabelsBatch(tx, packageInfo, action, batch);
+        const result = await signAndExecute(tx, network);
+        await client.waitForTransaction({ digest: result.digest });
+        console.log(`Transaction digest: ${result.digest}`);
+    }
+}


### PR DESCRIPTION
Validate labels and names before publishing the packages, to avoid potential manual actions after the packages were published for the case that the lists contain invalid labels.
Automatically remove duplicated labels and convert upper case entries to lowercase
Also split the labels to block/reserve into batches, to prevent exceeding the protocol limits for transactions

Fixes https://github.com/iotaledger/iota-names/issues/525
Tested locally by running the init script with large (over 3k) labels in the list so they had to be split into multiple txs