### PR TITLE
fix(indexer): temporarily use only historical store

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.10",
  "tap",
  "thiserror 1.0.69",
  "tokio",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "bin-version"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "const-str",
  "git-version",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1453,6 +1453,45 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic 0.12.3",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1838,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2240,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "serde_yaml",
 ]
@@ -3203,7 +3242,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3514,9 +3553,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3528,7 +3578,6 @@ dependencies = [
  "iota-verifier-latest",
  "leb128",
  "move-binary-format",
- "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-core-types",
@@ -3545,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3558,7 +3607,6 @@ dependencies = [
  "iota-genesis-common",
  "iota-keys",
  "iota-names",
- "iota-protocol-config",
  "iota-rest-api",
  "iota-types",
  "move-vm-config",
@@ -3610,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "iota-data-ingestion-core"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "serde_yaml",
 ]
@@ -3652,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3660,23 +3708,22 @@ dependencies = [
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
- "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-trace-format",
  "move-vm-config",
  "move-vm-runtime",
+ "move-vm-types",
 ]
 
 [[package]]
 name = "iota-framework"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "bcs",
  "iota-types",
  "move-binary-format",
  "move-core-types",
- "once_cell",
  "serde",
  "tracing",
 ]
@@ -3684,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3700,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-common"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3709,9 +3756,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-http"
+version = "1.4.0-alpha"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.15",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
 name = "iota-json"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3728,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3748,11 +3815,10 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
- "chrono",
  "colored",
  "enum_dispatch",
  "fastcrypto",
@@ -3769,6 +3835,8 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -3781,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3791,16 +3859,18 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with",
  "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
  "tiny-bip39",
+ "tracing",
 ]
 
 [[package]]
 name = "iota-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3811,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3837,18 +3907,16 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "fastcrypto",
  "iota-package-management",
- "iota-protocol-config",
  "iota-types",
  "iota-verifier-latest",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
- "move-command-line-common",
  "move-compiler",
  "move-core-types",
  "move-ir-types",
@@ -3861,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "bcs",
  "better_any",
@@ -3884,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "iota-names"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3930,10 +3998,9 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anemo",
- "async-stream",
  "bcs",
  "bytes",
  "eyre",
@@ -3942,6 +4009,7 @@ dependencies = [
  "http-body",
  "hyper-rustls",
  "hyper-util",
+ "iota-http",
  "multiaddr",
  "once_cell",
  "pin-project-lite",
@@ -3949,7 +4017,6 @@ dependencies = [
  "snap",
  "tokio",
  "tokio-rustls",
- "tokio-stream",
  "tonic 0.13.1",
  "tonic-health",
  "tower 0.4.13",
@@ -3960,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3971,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3984,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3996,23 +4063,20 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
 name = "iota-package-resolver"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "async-trait",
  "bcs",
- "eyre",
  "iota-types",
  "lru",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
- "serde",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -4020,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -4031,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -4046,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4056,10 +4120,9 @@ dependencies = [
 [[package]]
 name = "iota-rest-api"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
- "async-trait",
  "axum 0.8.4",
  "bcs",
  "fastcrypto",
@@ -4072,7 +4135,6 @@ dependencies = [
  "move-binary-format",
  "openapiv3",
  "prometheus",
- "rand 0.8.5",
  "reqwest",
  "schemars 0.8.22",
  "serde",
@@ -4080,7 +4142,6 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "tap",
- "thiserror 1.0.69",
  "tokio",
  "url",
 ]
@@ -4088,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6bb6e45fea2c266f9c15dd89f26f68631c2d37a8#6bb6e45fea2c266f9c15dd89f26f68631c2d37a8"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
 dependencies = [
  "base64ct",
  "bcs",
@@ -4140,13 +4201,12 @@ dependencies = [
 [[package]]
 name = "iota-sdk"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
  "bcs",
- "clap",
  "colored",
  "fastcrypto",
  "futures",
@@ -4175,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4198,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "iota-storage"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4214,11 +4274,9 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper",
- "hyper-rustls",
  "indicatif",
  "integer-encoding",
  "iota-config",
- "iota-json-rpc-types",
  "iota-metrics",
  "iota-protocol-config",
  "iota-simulator",
@@ -4226,9 +4284,6 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "moka",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
  "num_enum",
  "object_store",
  "parking_lot 0.12.4",
@@ -4252,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-builder"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4269,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4278,7 +4333,6 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
- "chrono",
  "consensus-config",
  "derive_more 1.0.0",
  "either",
@@ -4301,11 +4355,8 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "move-disassembler",
- "move-ir-types",
  "move-vm-profiler",
  "move-vm-test-utils",
- "move-vm-types",
  "nonempty",
  "num-bigint 0.4.6",
  "num-rational",
@@ -4337,9 +4388,8 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
- "iota-protocol-config",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5090,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5099,12 +5149,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5118,12 +5168,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5139,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -5153,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5168,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5178,7 +5228,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5187,11 +5237,9 @@ dependencies = [
  "insta",
  "move-binary-format",
  "move-core-types",
- "num-bigint 0.4.6",
  "once_cell",
  "serde",
  "sha2 0.9.9",
- "similar",
  "vfs",
  "walkdir",
 ]
@@ -5199,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5234,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5250,6 +5298,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "serde_with",
  "thiserror 1.0.69",
  "uint",
 ]
@@ -5257,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5278,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5299,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5322,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5340,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5353,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5366,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5386,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5421,7 +5470,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -5430,7 +5479,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5445,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "once_cell",
  "phf",
@@ -5455,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5466,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5475,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5485,7 +5534,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "better_any",
  "fail",
@@ -5505,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5519,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5532,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.44.2#56d9b6bec24b99e0d38329f244d418299ab04d71"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.46.1#20adc0b089bf9072268eea0f059fb8ea2461702f"
 dependencies = [
  "ahash",
  "async-task",
@@ -5549,7 +5598,7 @@ dependencies = [
  "rand 0.8.5",
  "real_tokio",
  "serde",
- "socket2",
+ "socket2 0.5.10",
  "tap",
  "tokio-util 0.7.13",
  "toml 0.8.23",
@@ -5560,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.44.2#56d9b6bec24b99e0d38329f244d418299ab04d71"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.46.1#20adc0b089bf9072268eea0f059fb8ea2461702f"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -6788,11 +6837,10 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "anyhow",
  "prometheus",
- "protobuf",
 ]
 
 [[package]]
@@ -6819,12 +6867,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
- "bytes",
  "once_cell",
  "protobuf-support",
  "thiserror 1.0.69",
@@ -6887,7 +6943,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -6924,7 +6980,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7150,7 +7206,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros 2.5.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=msim-1.43.0)",
  "windows-sys 0.52.0",
 ]
@@ -7825,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -8001,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "bcs",
  "eyre",
@@ -8153,6 +8209,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8496,12 +8562,13 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "atomic_float",
  "bytes",
  "bytes-varint",
  "clap",
+ "console-subscriber",
  "crossterm",
  "futures",
  "once_cell",
@@ -8698,21 +8765,23 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.4",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8904,7 +8973,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -8933,7 +9002,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
@@ -9205,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -9234,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -9245,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#336ca738f3d0e445b5da79bf0614d5c41e271fc5"
+source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -10,25 +10,10 @@ description = "IOTA-Names Indexer"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-axum = { version = "0.8", default-features = false, features = [
-    "tokio",
-    "http1",
-    "http2",
-    "json",
-    "matched-path",
-    "original-uri",
-    "form",
-    "query",
-    "ws",
-    "macros",
-] }
+axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
 bcs = "0.1"
 clap = { version = "4.4", features = ["derive", "wrap_help", "env"] }
-diesel = { version = "2.2.0", features = [
-    "sqlite",
-    "returning_clauses_for_sqlite_3_35",
-    "r2d2",
-] }
+diesel = { version = "2.2.0", features = ["sqlite", "returning_clauses_for_sqlite_3_35", "r2d2"] }
 diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 dotenvy = "0.15"
 futures = "0.3"
@@ -40,15 +25,7 @@ tokio = "1.47"
 tokio-util = "0.7"
 tower-http = { version = "0.6.6", features = ["cors"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "std",
-    "fmt",
-    "ansi",
-    "smallvec",
-    "tracing-log",
-    "local-time",
-    "env-filter",
-] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "ansi", "smallvec", "tracing-log", "local-time", "env-filter"] }
 
 bin-version = { git = "https://github.com/iotaledger/iota", package = "bin-version" }
 iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota", package = "iota-data-ingestion-core" }

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -10,10 +10,25 @@ description = "IOTA-Names Indexer"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
+axum = { version = "0.8", default-features = false, features = [
+    "tokio",
+    "http1",
+    "http2",
+    "json",
+    "matched-path",
+    "original-uri",
+    "form",
+    "query",
+    "ws",
+    "macros",
+] }
 bcs = "0.1"
 clap = { version = "4.4", features = ["derive", "wrap_help", "env"] }
-diesel = { version = "2.2.0", features = ["sqlite", "returning_clauses_for_sqlite_3_35", "r2d2"] }
+diesel = { version = "2.2.0", features = [
+    "sqlite",
+    "returning_clauses_for_sqlite_3_35",
+    "r2d2",
+] }
 diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 dotenvy = "0.15"
 futures = "0.3"
@@ -21,11 +36,19 @@ prometheus = "0.14"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = "=1.44.2"
+tokio = "1.47"
 tokio-util = "0.7"
 tower-http = { version = "0.6.6", features = ["cors"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "ansi", "smallvec", "tracing-log", "local-time", "env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "fmt",
+    "ansi",
+    "smallvec",
+    "tracing-log",
+    "local-time",
+    "env-filter",
+] }
 
 bin-version = { git = "https://github.com/iotaledger/iota", package = "bin-version" }
 iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota", package = "iota-data-ingestion-core" }

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -87,8 +87,8 @@ pub(crate) async fn run_iota_names_reader(
     } else {
         let config = CheckpointReaderConfig {
             remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
-                historical_url: checkpoint_url.to_string(),
-                live_url: Some(format!("{checkpoint_url}/ingestion/live")),
+                historical_url: format!("{checkpoint_url}/ingestion/historical"),
+                live_url: None,
             }),
             ingestion_path: Some(PathBuf::from("./data/chk")),
             ..Default::default()


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-names/issues/488 and hopefully resolve the current syncing issue we have
For some reason the live checkpoint store seems to lag behind quite a bit (sometimes took 1 - 1.5 hours to continue syncing) and infra team recommended to only rely on the historical store for now until they found the issue