### PR TITLE
fix(indexer): update to reader fix #8074

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "bin-version"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "const-str",
  "git-version",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1877,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "serde_yaml",
 ]
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "iota-data-ingestion-core"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "serde_yaml",
 ]
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "iota-framework"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-common"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "iota-http"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "bytes",
  "http",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "iota-json"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "iota-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "bcs",
  "better_any",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "iota-names"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anemo",
  "bcs",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "iota-package-resolver"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "async-trait",
  "bcs",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -4095,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "iota-rest-api"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -4201,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "iota-storage"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-builder"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4324,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "iota-types",
  "move-abstract-interpreter",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5149,12 +5149,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5168,12 +5168,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5189,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5218,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5228,7 +5228,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5247,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5306,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5327,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "clap",
@@ -5371,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "hex",
@@ -5402,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "clap",
@@ -5470,7 +5470,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -5479,7 +5479,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5494,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "once_cell",
  "phf",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5515,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5524,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5534,7 +5534,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "better_any",
  "fail",
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8057,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "bcs",
  "eyre",
@@ -8562,7 +8562,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "async-trait",
  "bcs",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "1.4.0-alpha"
-source = "git+https://github.com/iotaledger/iota#b748cc4b285c7f7f195fa73cf18fb211cc7878b6"
+source = "git+https://github.com/iotaledger/iota#d324f0a870e2de59a227c81b20820d8860272b21"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -72,6 +72,10 @@ pub(crate) async fn run_iota_names_reader(
     executor.register(worker_pool).await?;
 
     info!("Connecting to {checkpoint_url} to sync checkpoints");
+    let reader_options = ReaderOptions {
+        timeout_secs: 60,
+        ..Default::default()
+    };
     // Localnet does not support remote store, so we use the REST API
     if checkpoint_url.contains("localhost") || checkpoint_url.contains("host.docker.internal") {
         executor
@@ -81,17 +85,17 @@ pub(crate) async fn run_iota_names_reader(
                 Some(format!("{checkpoint_url}/api/v1")),
                 // optional remote store access options.
                 vec![],
-                ReaderOptions::default(),
+                reader_options,
             )
             .await?;
     } else {
         let config = CheckpointReaderConfig {
             remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
                 historical_url: format!("{checkpoint_url}/ingestion/historical"),
-                live_url: None,
+                live_url: Some(format!("{checkpoint_url}/ingestion/live")),
             }),
             ingestion_path: Some(PathBuf::from("./data/chk")),
-            ..Default::default()
+            reader_options,
         };
         executor.run_with_config(config).await?;
     }


### PR DESCRIPTION
https://github.com/iotaledger/iota/pull/8074 fixed a bug in the iota-data-ingestion-core that causes issue syncing the IOTA-Names indexer, with this fix in place it should be fine again
Also set the timeout to 60 seconds as the default 5 might be too short