### PR TITLE
feat(coupons): make Coupon getters public

### DIFF
--- a/packages/coupons/sources/coupon.move
+++ b/packages/coupons/sources/coupon.move
@@ -40,7 +40,8 @@ public(package) fun new_fixed(amount: u64, rules: CouponRules): Coupon {
     }
 }
 
-public(package) fun rules(coupon: &Coupon): &CouponRules {
+/// Get the rules of a coupon.
+public fun rules(coupon: &Coupon): &CouponRules {
     &coupon.rules
 }
 
@@ -48,14 +49,17 @@ public(package) fun rules_mut(coupon: &mut Coupon): &mut CouponRules {
     &mut coupon.rules
 }
 
-public(package) fun is_percentage(coupon: &Coupon): bool {
+/// Check whether a coupon applies a percentage discount.
+public fun is_percentage(coupon: &Coupon): bool {
     coupon.kind == PERCENTAGE_COUPON_KIND
 }
 
-public(package) fun is_fixed(coupon: &Coupon): bool {
+/// Check whether a coupon applies a fixed discount.
+public fun is_fixed(coupon: &Coupon): bool {
     coupon.kind == FIXED_COUPON_KIND
 }
 
-public(package) fun discount(coupon: &Coupon): u64 {
+/// Get the discount amount of a coupon.
+public fun discount(coupon: &Coupon): u64 {
     coupon.amount
 }

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -655,3 +655,26 @@ fun init_renewal(
 
     intent
 }
+
+#[test]
+fun test_coupon_getters() {
+    use iota_names_coupons::coupon;
+    use iota_names_coupons::rules;
+    let rules = rules::new_coupon_rules(option::none(), option::none(), option::none(), option::none(), option::none(), false);
+    let percentage_coupon = coupon::new_percentage(25, rules);
+    let fixed_coupon = coupon::new_fixed(1000, rules);
+
+    // Test rules getter
+    assert!(&coupon::rules(&percentage_coupon) == &percentage_coupon.rules);
+    assert!(&coupon::rules(&fixed_coupon) == &fixed_coupon.rules);
+
+    // Test is_percentage and is_fixed
+    assert!(coupon::is_percentage(&percentage_coupon));
+    assert!(!coupon::is_fixed(&percentage_coupon));
+    assert!(!coupon::is_percentage(&fixed_coupon));
+    assert!(coupon::is_fixed(&fixed_coupon));
+
+    // Test discount getter
+    assert!(coupon::discount(&percentage_coupon) == 25);
+    assert!(coupon::discount(&fixed_coupon) == 1000);
+}

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -14,6 +14,7 @@ use iota_names::iota_names::IotaNames;
 use iota_names::name_registration::NameRegistration;
 use iota_names::payment::PaymentIntent;
 use iota_names_coupons::coupon_house;
+use iota_names_coupons::coupon;
 use iota_names_coupons::coupons;
 use iota_names_coupons::range;
 use iota_names_coupons::rules;
@@ -658,15 +659,13 @@ fun init_renewal(
 
 #[test]
 fun test_coupon_getters() {
-    use iota_names_coupons::coupon;
-    use iota_names_coupons::rules;
     let rules = rules::new_coupon_rules(option::none(), option::none(), option::none(), option::none(), option::none(), false);
     let percentage_coupon = coupon::new_percentage(25, rules);
     let fixed_coupon = coupon::new_fixed(1000, rules);
 
     // Test rules getter
-    assert!(&coupon::rules(&percentage_coupon) == &percentage_coupon.rules);
-    assert!(&coupon::rules(&fixed_coupon) == &fixed_coupon.rules);
+    assert!(percentage_coupon.rules() == &rules);
+    assert!(fixed_coupon.rules() == &rules);
 
     // Test is_percentage and is_fixed
     assert!(coupon::is_percentage(&percentage_coupon));


### PR DESCRIPTION
Make Coupon getters public, they could be useful for others and there is no harm in doing that

Fixes https://github.com/iotaledger/iota-names/issues/528

Added a test for them