### PR TITLE
feat(indexer): Add paging info in auction API reponses

### DIFF
--- a/indexer/src/api/mod.rs
+++ b/indexer/src/api/mod.rs
@@ -10,6 +10,7 @@ use crate::db::pool::DbConnectionPool;
 
 mod error;
 mod extractors;
+mod responses;
 mod routes;
 
 #[derive(Clone)]

--- a/indexer/src/api/responses.rs
+++ b/indexer/src/api/responses.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuctionsResponse {
+    pub names: Vec<String>,
+    pub page: usize,
+    pub page_size: usize,
+    pub total_items: usize,
+}
+
+impl axum::response::IntoResponse for AuctionsResponse {
+    fn into_response(self) -> axum::response::Response {
+        axum::Json(self).into_response()
+    }
+}

--- a/indexer/src/api/responses.rs
+++ b/indexer/src/api/responses.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuctionsResponse {
     pub names: Vec<String>,
     pub page: usize,

--- a/indexer/src/api/routes.rs
+++ b/indexer/src/api/routes.rs
@@ -25,7 +25,7 @@ pub fn routes() -> Router<ApiState> {
     Router::new()
         .route("/health", get(health_check))
         .route("/auctions", get(get_auctions))
-        .route("/auctions/{address}", get(get_names_for_address))
+        .route("/auctions/{address}", get(get_auctions_for_address))
         .layer(
             CorsLayer::new()
                 .allow_origin(Any)
@@ -38,7 +38,7 @@ async fn health_check() -> &'static str {
     "OK"
 }
 
-async fn get_names_for_address(
+async fn get_auctions_for_address(
     State(state): State<ApiState>,
     Path(address_str): Path<String>,
     BidderNamesPagination {
@@ -56,7 +56,7 @@ async fn get_names_for_address(
         total_items = queries::get_names_for_bidder_count(&mut conn, bidder.id)?;
 
         if total_items > 0 {
-            queries::get_names_for_bidder(&mut conn, bidder.id, page, page_size, sort)?
+            queries::get_auctions_for_bidder(&mut conn, bidder.id, page, page_size, sort)?
         } else {
             Default::default()
         }

--- a/indexer/src/api/routes.rs
+++ b/indexer/src/api/routes.rs
@@ -53,7 +53,7 @@ async fn get_auctions_for_address(
     let mut conn = state.pool.get_connection()?;
     let mut total_items = 0;
     let names = if let Some(bidder) = queries::get_bidder_by_address(&mut conn, &address_str)? {
-        total_items = queries::get_names_for_bidder_count(&mut conn, bidder.id)?;
+        total_items = queries::get_auctions_for_bidder_count(&mut conn, bidder.id)?;
 
         if total_items > 0 {
             queries::get_auctions_for_bidder(&mut conn, bidder.id, page, page_size, sort)?

--- a/indexer/src/api/routes.rs
+++ b/indexer/src/api/routes.rs
@@ -4,17 +4,21 @@
 use std::str::FromStr;
 
 use axum::{
-    Json, Router,
+    Router,
     extract::{Path, State},
     routing::get,
 };
 use iota_types::base_types::IotaAddress;
 use tower_http::cors::{Any, CorsLayer};
 
-use crate::api::{
-    ApiState,
-    error::ApiError,
-    extractors::{AuctionsPagination, BidderNamesPagination},
+use crate::{
+    api::{
+        ApiState,
+        error::ApiError,
+        extractors::{AuctionsPagination, BidderNamesPagination},
+        responses::AuctionsResponse,
+    },
+    db::queries,
 };
 
 pub fn routes() -> Router<ApiState> {
@@ -42,20 +46,30 @@ async fn get_names_for_address(
         page_size,
         sort,
     }: BidderNamesPagination,
-) -> Result<Json<Vec<String>>, ApiError> {
+) -> Result<AuctionsResponse, ApiError> {
     IotaAddress::from_str(&address_str)
         .map_err(|_| ApiError::BadRequest("Invalid IOTA address".to_string()))?;
 
     let mut conn = state.pool.get_connection()?;
-    let names = crate::db::queries::get_names_for_bidder_address(
-        &mut conn,
-        &address_str,
-        page,
-        page_size,
-        sort,
-    )?;
+    let mut total_items = 0;
+    let names = if let Some(bidder) = queries::get_bidder_by_address(&mut conn, &address_str)? {
+        total_items = queries::get_names_for_bidder_count(&mut conn, bidder.id)?;
 
-    Ok(Json(names))
+        if total_items > 0 {
+            queries::get_names_for_bidder(&mut conn, bidder.id, page, page_size, sort)?
+        } else {
+            Default::default()
+        }
+    } else {
+        Default::default()
+    };
+
+    Ok(AuctionsResponse {
+        names,
+        page: page.unwrap_or_default(),
+        page_size,
+        total_items,
+    })
 }
 
 async fn get_auctions(
@@ -67,10 +81,19 @@ async fn get_auctions(
         sort_by,
         search,
     }: AuctionsPagination,
-) -> Result<Json<Vec<String>>, ApiError> {
+) -> Result<AuctionsResponse, ApiError> {
     let mut conn = state.pool.get_connection()?;
-    let names =
-        crate::db::queries::get_auctions(&mut conn, page, page_size, sort, sort_by, search)?;
+    let total_items = queries::get_auctions_count(&mut conn, search.as_deref())?;
+    let names = if total_items > 0 {
+        queries::get_auctions(&mut conn, page, page_size, sort, sort_by, search.as_deref())?
+    } else {
+        Default::default()
+    };
 
-    Ok(Json(names))
+    Ok(AuctionsResponse {
+        names,
+        page: page.unwrap_or_default(),
+        page_size,
+        total_items,
+    })
 }

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -98,7 +98,6 @@ pub fn get_auctions_for_bidder(
 pub fn get_auctions_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32) -> Result<usize> {
     Ok(bids::table
         .inner_join(names::table)
-        .group_by(names::id)
         .select(dsl::count_distinct(names::id))
         .filter(bids::bidder_id.eq(bidder_id))
         .first::<i64>(conn)? as _)

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -99,7 +99,7 @@ pub fn get_auctions_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32
     Ok(bids::table
         .inner_join(names::table)
         .group_by(names::id)
-        .select(dsl::count_distinct(names::name))
+        .select(dsl::count_distinct(names::id))
         .filter(bids::bidder_id.eq(bidder_id))
         .first::<i64>(conn)? as _)
 }

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -71,7 +71,7 @@ pub fn get_bidder_by_address(conn: &mut SqliteConnection, address: &str) -> Resu
         .optional()?)
 }
 
-pub fn get_names_for_bidder(
+pub fn get_auctions_for_bidder(
     conn: &mut SqliteConnection,
     bidder_id: i32,
     page: Option<usize>,

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -95,7 +95,7 @@ pub fn get_auctions_for_bidder(
     Ok(query.load(conn)?)
 }
 
-pub fn get_names_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32) -> Result<usize> {
+pub fn get_auctions_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32) -> Result<usize> {
     Ok(bids::table
         .inner_join(names::table)
         .group_by(names::id)

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -3,11 +3,11 @@
 
 use anyhow::Result;
 use diesel::{
-    BelongingToDsl, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
+    ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
     SqliteConnection, TextExpressionMethods, dsl, insert_into,
 };
 
-use super::models::{Bid, Bidder, Name, bidders, bids, names};
+use super::models::{Bidder, Name, bidders, bids, names};
 use crate::db::{AuctionSortBy, SortOrder};
 
 pub fn get_or_create_bidder(conn: &mut SqliteConnection, address: &str) -> Result<Bidder> {
@@ -63,29 +63,26 @@ pub fn add_bids_entry(
     Ok(())
 }
 
-pub fn get_names_for_bidder_address(
+pub fn get_bidder_by_address(conn: &mut SqliteConnection, address: &str) -> Result<Option<Bidder>> {
+    Ok(bidders::table
+        .filter(bidders::address.eq(address))
+        .select(Bidder::as_select())
+        .get_result(conn)
+        .optional()?)
+}
+
+pub fn get_names_for_bidder(
     conn: &mut SqliteConnection,
-    address: &str,
+    bidder_id: i32,
     page: Option<usize>,
     page_size: usize,
     sort: SortOrder,
 ) -> Result<Vec<String>> {
-    let bidder = bidders::table
-        .filter(bidders::address.eq(address))
-        .select(Bidder::as_select())
-        .get_result(conn)
-        .optional()?;
-
-    let bidder = match bidder {
-        Some(bidder) => bidder,
-        // Just return an empty vector if the bidder was not found
-        None => return Ok(vec![]),
-    };
-
-    let mut query = Bid::belonging_to(&bidder)
+    let mut query = bids::table
         .inner_join(names::table)
         .group_by(names::id)
         .select(names::name)
+        .filter(bids::bidder_id.eq(bidder_id))
         .limit(page_size as _)
         .offset((page.unwrap_or_default() * page_size) as _)
         .into_boxed();
@@ -98,13 +95,22 @@ pub fn get_names_for_bidder_address(
     Ok(query.load(conn)?)
 }
 
+pub fn get_names_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32) -> Result<usize> {
+    Ok(bids::table
+        .inner_join(names::table)
+        .group_by(names::id)
+        .select(dsl::count_distinct(names::name))
+        .filter(bids::bidder_id.eq(bidder_id))
+        .first::<i64>(conn)? as _)
+}
+
 pub fn get_auctions(
     conn: &mut SqliteConnection,
     page: Option<usize>,
     page_size: usize,
     sort: SortOrder,
     sort_by: AuctionSortBy,
-    search: Option<String>,
+    search: Option<&str>,
 ) -> Result<Vec<String>> {
     let mut query = names::table
         .inner_join(bids::table)
@@ -131,6 +137,17 @@ pub fn get_auctions(
         .into_iter()
         .map(|(name, _)| name.name)
         .collect())
+}
+
+pub fn get_auctions_count(conn: &mut SqliteConnection, search: Option<&str>) -> Result<usize> {
+    let mut query = names::table
+        .inner_join(bids::table)
+        .select(dsl::count_distinct(names::id))
+        .into_boxed();
+    if let Some(search) = search {
+        query = query.filter(names::name.like(format!("%{search}%")))
+    }
+    Ok(query.first::<i64>(conn)? as _)
 }
 
 pub fn get_bid_count(conn: &mut SqliteConnection, name_str: &str) -> Result<i64> {


### PR DESCRIPTION
## Description

Adds the `page`, `pageSize` and `totalItems` fields in the response of the auction endpoints.