### PR TITLE
feat(scripts): split registration of names into multiple txs

### DIFF
--- a/scripts/init/init.ts
+++ b/scripts/init/init.ts
@@ -7,7 +7,7 @@ import { Transaction } from '@iota/iota-sdk/transactions';
 
 import { readPackageInfo, writePackageInfo } from '../package-info/constants';
 import { parseLabelsFile, processLabelsFileBatched } from '../reserved-names/deny-labels';
-import { parseCsvFile, registerNames } from '../reserved-names/register-names';
+import { parseCsvFile, processNamesFileBatched } from '../reserved-names/register-names';
 import { getClient, getIotaNamesAdminObjects, signAndExecute } from '../utils/utils';
 import { publishPackages } from './publish';
 import { setup } from './setup';
@@ -62,31 +62,14 @@ export const init = async (
     // Register names
     let namesToRegisterFile = './init/names-to-register.csv';
     if (fs.existsSync(namesToRegisterFile)) {
-        const nameAddressPairs = parseCsvFile(namesToRegisterFile);
-        const names = Object.keys(nameAddressPairs);
-        const nameCount = names.length;
-        if (nameCount === 0) {
-            console.log('No names to register');
-        } else {
-            console.log(`Registering ${nameCount} names:`, names);
-            const tx = new Transaction();
-            registerNames(
-                tx,
-                names,
-                packageInfo.packageId,
-                packageInfo.adminCap,
-                packageInfo.iotaNamesObjectId,
-            );
-            const result = await signAndExecute(tx, network);
-            await client.waitForTransaction({ digest: result.digest });
-            console.log(`Transaction digest: ${result.digest}`);
-        }
+        await processNamesFileBatched(namesToRegisterFile, packageInfo, network, client);
     }
 
     if (!newOwner) {
         return;
     }
 
+    // Transfer ownership of the IOTA-Names objects to the new owner
     const objectsToTransfer = await getIotaNamesAdminObjects(packageInfo, client);
 
     const tx = new Transaction();

--- a/scripts/reserved-names/register-names.ts
+++ b/scripts/reserved-names/register-names.ts
@@ -6,6 +6,7 @@ import { Transaction } from '@iota/iota-sdk/transactions';
 import { IOTA_CLOCK_OBJECT_ID, isValidIotaAddress } from '@iota/iota-sdk/utils';
 
 import { isValidIotaName, normalizeIotaName } from '../../sdk/src/utils';
+import { signAndExecute } from '../utils/utils';
 
 const YEARS_TO_RESERVE = 1;
 
@@ -14,6 +15,7 @@ export const parseCsvFile = (filePath: string): Record<string, string | undefine
     const fileContent = fs.readFileSync(filePath).toString();
 
     const nameAddressPairs: Record<string, string | undefined> = {};
+    const seen = new Set<string>();
     fileContent
         .split('\n')
         // Ignore comments
@@ -25,6 +27,10 @@ export const parseCsvFile = (filePath: string): Record<string, string | undefine
             const normalizedName = normalizeIotaName(name + '.iota', 'dot');
             const isValidName = isValidIotaName(normalizedName);
             if (!isValidName) throw new Error(`Invalid name: ${address} | ${name}`);
+            if (seen.has(normalizedName)) {
+                return undefined; // skip duplicates
+            }
+            seen.add(normalizedName);
             if (address) {
                 const isValidAddress = isValidIotaAddress(address);
                 if (!isValidAddress) throw new Error(`Invalid address: ${address} | ${name}`);
@@ -53,6 +59,59 @@ export const registerNames = (
         ],
     });
 };
+
+// Arg size needs to be limited to not exceed protocol limits
+const PURE_ARG_SIZE_LIMIT = 8500;
+
+// Batch and process names from a file
+export async function processNamesFileBatched(
+    filePath: string,
+    packageInfo: {
+        packageId: string;
+        adminCap: string;
+        iotaNamesObjectId: string;
+    },
+    network: string,
+    client: any,
+) {
+    const nameAddressPairs = parseCsvFile(filePath);
+    const allNames = Object.keys(nameAddressPairs);
+    let batch: string[] = [];
+    let batchLen = 0;
+    for (const name of allNames) {
+        const nameLen = name.length + (batch.length > 0 ? 1 : 0);
+        if (batchLen + nameLen > PURE_ARG_SIZE_LIMIT) {
+            await sendNamesBatchTransaction(batch, packageInfo, network, client);
+            batch = [];
+            batchLen = 0;
+        }
+        batch.push(name);
+        batchLen += nameLen;
+    }
+    if (batch.length > 0) {
+        await sendNamesBatchTransaction(batch, packageInfo, network, client);
+    }
+}
+
+async function sendNamesBatchTransaction(
+    batch: string[],
+    packageInfo: { packageId: string; adminCap: string; iotaNamesObjectId: string },
+    network: string,
+    client: any,
+) {
+    const tx = new Transaction();
+    console.log(`Registering ${batch.length} names`);
+    registerNames(
+        tx,
+        batch,
+        packageInfo.packageId,
+        packageInfo.adminCap,
+        packageInfo.iotaNamesObjectId,
+    );
+    const result = await signAndExecute(tx, network);
+    await client.waitForTransaction({ digest: result.digest });
+    console.log(`Transaction digest: ${result.digest}`);
+}
 
 // Run this to see what names would be registered:
 // const nameAddressPairs = parseCsvFile('./init/names-to-register.csv');


### PR DESCRIPTION
Split names to register in the init script into multiple txs if needed, to prevent errors from exceeding protocol limits.

Fixes https://github.com/iotaledger/iota-names/issues/530

Tested by running the init script in a localnet with ~5k names like this `'000', '001', '002', '003', '004', '005', '006', '007', '008', '009', '00a', '00b',  '00c', '00d', '00e'` 

```
Setting up packages...
******* Packages set up successfully in 5PejSk8xKcZxfWfXsa7c8UtW1fTnA6cFRS6hLVc2FwqQ *******
Blocking 3 labels
Transaction digest: AGrYTeLLNQ3bBdUAajpBgDC9FZeYB3QT3vefvX6grvcu
Reserving 3 labels
Transaction digest: J3HotfZDTF7XCRu7vtyAGncnZ4p2kZzFXjJW4fi3Rpma
Registering 944 names
Transaction digest: 9qzzv9ty3HyNrMCTxXcZ9vJUPvm42vyo5SFSkgTT3BRs
Registering 944 names
Transaction digest: 694o9erP6zVT8K3Bm1BhVro2TCdjAiJU53kYBzcXXv64
Registering 944 names
Transaction digest: 9T7t118zFt6TLAoG54ncFFy5Z75hxaCk5ZWphcnFCiDD
Registering 944 names
Transaction digest: 5TfT2jfr4qWfsvJGYB4ubThSb7Mei7B3X7XiUEHDkoSU
Registering 944 names
Transaction digest: 6hQHR9fPj8n5aT2nsdDKt38UansFt3WbAKoBEYMntNNy
Registering 280 names
Transaction digest: 8rmLkRpBAQfrRxLGpFYexenL32QTq9SHgpdmsRrQMm2X
```