### PR TITLE
feat(indexer): Add `auctions` table to track auction statuses

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -3971,6 +3971,7 @@ dependencies = [
  "axum 0.8.4",
  "bcs",
  "bin-version",
+ "chrono",
  "clap",
  "diesel",
  "diesel_migrations",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
 bcs = "0.1"
+chrono = "0.4.41"
 clap = { version = "4.4", features = ["derive", "wrap_help", "env"] }
 diesel = { version = "2.2.0", features = ["sqlite", "returning_clauses_for_sqlite_3_35", "r2d2"] }
 diesel_migrations = { version = "2.2.0", features = ["sqlite"] }

--- a/indexer/migrations/2025-08-08-084513_add_claimed_names/down.sql
+++ b/indexer/migrations/2025-08-08-084513_add_claimed_names/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE `auctions`;

--- a/indexer/migrations/2025-08-08-084513_add_claimed_names/up.sql
+++ b/indexer/migrations/2025-08-08-084513_add_claimed_names/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+CREATE TABLE `auctions`(
+	`name_id` INTEGER NOT NULL,
+    `expiration_timestamp` INTEGER NOT NULL,
+    `claimed` BOOLEAN NOT NULL,
+	PRIMARY KEY (`name_id`),
+	FOREIGN KEY (`name_id`) REFERENCES `names`(`id`)
+);

--- a/indexer/src/api/extractors.rs
+++ b/indexer/src/api/extractors.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use crate::{
     api::error::ApiError,
-    db::{AuctionSortBy, SortOrder},
+    db::{AuctionSortBy, AuctionStatus, SortOrder},
 };
 
 const DEFAULT_PAGE_SIZE: usize = 50;
@@ -16,6 +16,7 @@ pub struct BidderNamesPagination {
     pub page: Option<usize>,
     pub page_size: usize,
     pub sort: SortOrder,
+    pub status: AuctionStatus,
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
@@ -31,6 +32,7 @@ impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
             page: Option<usize>,
             page_size: Option<usize>,
             sort: Option<String>,
+            status: Option<String>,
         }
 
         let Query(query) = Query::<BidderNamesPaginationQuery>::from_request_parts(parts, state)
@@ -43,6 +45,12 @@ impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
             .map_or(Ok(Default::default()), str::parse)
             .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
 
+        let status = query
+            .status
+            .as_deref()
+            .map_or(Ok(Default::default()), str::parse)
+            .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
+
         Ok(Self {
             page: query.page,
             page_size: query
@@ -50,6 +58,7 @@ impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
                 .unwrap_or(DEFAULT_PAGE_SIZE)
                 .min(MAX_PAGE_SIZE),
             sort,
+            status,
         })
     }
 }
@@ -60,6 +69,7 @@ pub struct AuctionsPagination {
     pub sort: SortOrder,
     pub sort_by: AuctionSortBy,
     pub search: Option<String>,
+    pub status: AuctionStatus,
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
@@ -77,6 +87,7 @@ impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
             sort: Option<String>,
             sort_by: Option<String>,
             search: Option<String>,
+            status: Option<String>,
         }
 
         let Query(query) = Query::<AuctionsPaginationQuery>::from_request_parts(parts, state)
@@ -95,6 +106,12 @@ impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
             .map_or(Ok(Default::default()), str::parse)
             .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
 
+        let status = query
+            .status
+            .as_deref()
+            .map_or(Ok(Default::default()), str::parse)
+            .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
+
         Ok(Self {
             page: query.page,
             page_size: query
@@ -104,6 +121,7 @@ impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
             sort,
             sort_by,
             search: query.search,
+            status,
         })
     }
 }

--- a/indexer/src/api/extractors.rs
+++ b/indexer/src/api/extractors.rs
@@ -16,7 +16,7 @@ pub struct BidderNamesPagination {
     pub page: Option<usize>,
     pub page_size: usize,
     pub sort: SortOrder,
-    pub status: AuctionStatus,
+    pub status: Option<AuctionStatus>,
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
@@ -48,7 +48,8 @@ impl<S: Send + Sync> FromRequestParts<S> for BidderNamesPagination {
         let status = query
             .status
             .as_deref()
-            .map_or(Ok(Default::default()), str::parse)
+            .map(str::parse)
+            .transpose()
             .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
 
         Ok(Self {
@@ -69,7 +70,7 @@ pub struct AuctionsPagination {
     pub sort: SortOrder,
     pub sort_by: AuctionSortBy,
     pub search: Option<String>,
-    pub status: AuctionStatus,
+    pub status: Option<AuctionStatus>,
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
@@ -109,7 +110,8 @@ impl<S: Send + Sync> FromRequestParts<S> for AuctionsPagination {
         let status = query
             .status
             .as_deref()
-            .map_or(Ok(Default::default()), str::parse)
+            .map(str::parse)
+            .transpose()
             .map_err(|e: anyhow::Error| ApiError::BadRequest(e.to_string()))?;
 
         Ok(Self {

--- a/indexer/src/api/routes.rs
+++ b/indexer/src/api/routes.rs
@@ -45,6 +45,7 @@ async fn get_auctions_for_address(
         page,
         page_size,
         sort,
+        status,
     }: BidderNamesPagination,
 ) -> Result<AuctionsResponse, ApiError> {
     IotaAddress::from_str(&address_str)
@@ -52,11 +53,14 @@ async fn get_auctions_for_address(
 
     let mut conn = state.pool.get_connection()?;
     let mut total_items = 0;
+    let now = chrono::Utc::now();
     let names = if let Some(bidder) = queries::get_bidder_by_address(&mut conn, &address_str)? {
-        total_items = queries::get_auctions_for_bidder_count(&mut conn, bidder.id)?;
+        total_items = queries::get_auctions_for_bidder_count(&mut conn, bidder.id, status, now)?;
 
         if total_items > 0 {
-            queries::get_auctions_for_bidder(&mut conn, bidder.id, page, page_size, sort)?
+            queries::get_auctions_for_bidder(
+                &mut conn, bidder.id, page, page_size, sort, status, now,
+            )?
         } else {
             Default::default()
         }
@@ -80,12 +84,23 @@ async fn get_auctions(
         sort,
         sort_by,
         search,
+        status,
     }: AuctionsPagination,
 ) -> Result<AuctionsResponse, ApiError> {
     let mut conn = state.pool.get_connection()?;
-    let total_items = queries::get_auctions_count(&mut conn, search.as_deref())?;
+    let now = chrono::Utc::now();
+    let total_items = queries::get_auctions_count(&mut conn, search.as_deref(), status, now)?;
     let names = if total_items > 0 {
-        queries::get_auctions(&mut conn, page, page_size, sort, sort_by, search.as_deref())?
+        queries::get_auctions(
+            &mut conn,
+            page,
+            page_size,
+            sort,
+            sort_by,
+            search.as_deref(),
+            status,
+            now,
+        )?
     } else {
         Default::default()
     };

--- a/indexer/src/db/mod.rs
+++ b/indexer/src/db/mod.rs
@@ -46,3 +46,26 @@ impl std::str::FromStr for AuctionSortBy {
         })
     }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum AuctionStatus {
+    #[default]
+    Active,
+    Finished,
+    Claimed,
+}
+
+impl std::str::FromStr for AuctionStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "active" => AuctionStatus::Active,
+            "finished" => AuctionStatus::Finished,
+            "claimed" => AuctionStatus::Claimed,
+            _ => Err(anyhow::anyhow!(
+                "Invalid status descriptor. Expected `active`, `finished`, or `claimed`, found `{s}`"
+            ))?,
+        })
+    }
+}

--- a/indexer/src/db/models.rs
+++ b/indexer/src/db/models.rs
@@ -28,6 +28,16 @@ pub struct Bid {
     pub bid: i64,
 }
 
+#[derive(Identifiable, Selectable, Queryable, Associations, Debug)]
+#[diesel(belongs_to(Name))]
+#[diesel(table_name = auctions)]
+#[diesel(primary_key(name_id))]
+pub struct Auction {
+    pub name_id: i32,
+    pub expiration_timestamp: i64,
+    pub claimed: bool,
+}
+
 diesel::table! {
     names (id) {
         id -> Int4,
@@ -57,7 +67,16 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    auctions (name_id) {
+        name_id -> Int4,
+        expiration_timestamp -> Int8,
+        claimed -> Bool
+    }
+}
+
 diesel::joinable!(bids -> names (name_id));
 diesel::joinable!(bids -> bidders (bidder_id));
+diesel::joinable!(auctions -> names (name_id));
 
-diesel::allow_tables_to_appear_in_same_query!(bidders, names, bids);
+diesel::allow_tables_to_appear_in_same_query!(bidders, names, bids, auctions);

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use diesel::{
     ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
-    SqliteConnection, TextExpressionMethods, dsl, insert_into,
+    SqliteConnection, TextExpressionMethods, dsl, insert_into, update,
 };
 
-use super::models::{Bidder, Name, bidders, bids, names};
-use crate::db::{AuctionSortBy, SortOrder};
+use crate::db::{
+    AuctionSortBy, AuctionStatus, SortOrder,
+    models::{Bidder, Name, auctions, bidders, bids, names},
+};
 
 pub fn get_or_create_bidder(conn: &mut SqliteConnection, address: &str) -> Result<Bidder> {
     let maybe_bidder = insert_into(bidders::table)
@@ -46,12 +49,10 @@ pub fn get_or_create_name(conn: &mut SqliteConnection, name: &str) -> Result<Nam
 
 pub fn add_bids_entry(
     conn: &mut SqliteConnection,
-    bidder_address: &str,
-    name_str: &str,
+    bidder: &Bidder,
+    name: &Name,
     bid: u64,
 ) -> Result<()> {
-    let bidder = get_or_create_bidder(conn, bidder_address)?;
-    let name = get_or_create_name(conn, name_str)?;
     insert_into(bids::table)
         .values((
             bids::bidder_id.eq(bidder.id),
@@ -59,6 +60,31 @@ pub fn add_bids_entry(
             bids::bid.eq(bid as i64),
         ))
         .on_conflict_do_nothing()
+        .execute(conn)?;
+    Ok(())
+}
+
+pub fn upsert_auctions_entry(
+    conn: &mut SqliteConnection,
+    name: &Name,
+    expiration_timestamp: i64,
+) -> Result<()> {
+    insert_into(auctions::table)
+        .values((
+            auctions::name_id.eq(name.id),
+            auctions::expiration_timestamp.eq(expiration_timestamp),
+            auctions::claimed.eq(false),
+        ))
+        .on_conflict(auctions::name_id)
+        .do_update()
+        .set(auctions::expiration_timestamp.eq(expiration_timestamp))
+        .execute(conn)?;
+    Ok(())
+}
+
+pub fn claim_auctions_entry(conn: &mut SqliteConnection, name: &Name) -> Result<()> {
+    update(auctions::table.filter(auctions::name_id.eq(name.id)))
+        .set((auctions::claimed.eq(true),))
         .execute(conn)?;
     Ok(())
 }
@@ -77,15 +103,24 @@ pub fn get_auctions_for_bidder(
     page: Option<usize>,
     page_size: usize,
     sort: SortOrder,
+    status: AuctionStatus,
+    now: DateTime<Utc>,
 ) -> Result<Vec<String>> {
-    let mut query = bids::table
-        .inner_join(names::table)
+    let mut query = names::table
+        .inner_join(bids::table)
+        .inner_join(auctions::table)
         .group_by(names::id)
         .select(names::name)
         .filter(bids::bidder_id.eq(bidder_id))
         .limit(page_size as _)
         .offset((page.unwrap_or_default() * page_size) as _)
         .into_boxed();
+
+    query = match status {
+        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
+        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
+        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+    };
 
     query = match sort {
         SortOrder::Asc => query.order(names::name.asc()),
@@ -95,12 +130,26 @@ pub fn get_auctions_for_bidder(
     Ok(query.load(conn)?)
 }
 
-pub fn get_auctions_for_bidder_count(conn: &mut SqliteConnection, bidder_id: i32) -> Result<usize> {
-    Ok(bids::table
-        .inner_join(names::table)
+pub fn get_auctions_for_bidder_count(
+    conn: &mut SqliteConnection,
+    bidder_id: i32,
+    status: AuctionStatus,
+    now: DateTime<Utc>,
+) -> Result<usize> {
+    let mut query = names::table
+        .inner_join(bids::table)
+        .inner_join(auctions::table)
         .select(dsl::count_distinct(names::id))
         .filter(bids::bidder_id.eq(bidder_id))
-        .first::<i64>(conn)? as _)
+        .into_boxed();
+
+    query = match status {
+        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
+        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
+        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+    };
+
+    Ok(query.first::<i64>(conn)? as _)
 }
 
 pub fn get_auctions(
@@ -110,9 +159,12 @@ pub fn get_auctions(
     sort: SortOrder,
     sort_by: AuctionSortBy,
     search: Option<&str>,
+    status: AuctionStatus,
+    now: DateTime<Utc>,
 ) -> Result<Vec<String>> {
     let mut query = names::table
         .inner_join(bids::table)
+        .inner_join(auctions::table)
         .group_by(names::id)
         .select((Name::as_select(), dsl::max(bids::bid)))
         .limit(page_size as _)
@@ -121,6 +173,11 @@ pub fn get_auctions(
     if let Some(search) = search {
         query = query.filter(names::name.like(format!("%{search}%")))
     }
+    query = match status {
+        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
+        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
+        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+    };
     query = match (sort, sort_by) {
         (SortOrder::Asc, AuctionSortBy::Name) => query.order(names::name.asc()),
         (SortOrder::Desc, AuctionSortBy::Name) => query.order(names::name.desc()),
@@ -138,14 +195,28 @@ pub fn get_auctions(
         .collect())
 }
 
-pub fn get_auctions_count(conn: &mut SqliteConnection, search: Option<&str>) -> Result<usize> {
+pub fn get_auctions_count(
+    conn: &mut SqliteConnection,
+    search: Option<&str>,
+    status: AuctionStatus,
+    now: DateTime<Utc>,
+) -> Result<usize> {
     let mut query = names::table
         .inner_join(bids::table)
+        .inner_join(auctions::table)
         .select(dsl::count_distinct(names::id))
         .into_boxed();
+
+    query = match status {
+        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
+        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
+        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+    };
+
     if let Some(search) = search {
         query = query.filter(names::name.like(format!("%{search}%")))
     }
+
     Ok(query.first::<i64>(conn)? as _)
 }
 

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -103,7 +103,7 @@ pub fn get_auctions_for_bidder(
     page: Option<usize>,
     page_size: usize,
     sort: SortOrder,
-    status: AuctionStatus,
+    status: Option<AuctionStatus>,
     now: DateTime<Utc>,
 ) -> Result<Vec<String>> {
     let mut query = names::table
@@ -116,11 +116,17 @@ pub fn get_auctions_for_bidder(
         .offset((page.unwrap_or_default() * page_size) as _)
         .into_boxed();
 
-    query = match status {
-        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
-        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
-        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
-    };
+    if let Some(status) = status {
+        query = match status {
+            AuctionStatus::Active => {
+                query.filter(auctions::expiration_timestamp.gt(now.timestamp()))
+            }
+            AuctionStatus::Finished => {
+                query.filter(auctions::expiration_timestamp.le(now.timestamp()))
+            }
+            AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+        };
+    }
 
     query = match sort {
         SortOrder::Asc => query.order(names::name.asc()),
@@ -133,7 +139,7 @@ pub fn get_auctions_for_bidder(
 pub fn get_auctions_for_bidder_count(
     conn: &mut SqliteConnection,
     bidder_id: i32,
-    status: AuctionStatus,
+    status: Option<AuctionStatus>,
     now: DateTime<Utc>,
 ) -> Result<usize> {
     let mut query = names::table
@@ -143,11 +149,17 @@ pub fn get_auctions_for_bidder_count(
         .filter(bids::bidder_id.eq(bidder_id))
         .into_boxed();
 
-    query = match status {
-        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
-        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
-        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
-    };
+    if let Some(status) = status {
+        query = match status {
+            AuctionStatus::Active => {
+                query.filter(auctions::expiration_timestamp.gt(now.timestamp()))
+            }
+            AuctionStatus::Finished => {
+                query.filter(auctions::expiration_timestamp.le(now.timestamp()))
+            }
+            AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+        };
+    }
 
     Ok(query.first::<i64>(conn)? as _)
 }
@@ -160,7 +172,7 @@ pub fn get_auctions(
     sort: SortOrder,
     sort_by: AuctionSortBy,
     search: Option<&str>,
-    status: AuctionStatus,
+    status: Option<AuctionStatus>,
     now: DateTime<Utc>,
 ) -> Result<Vec<String>> {
     let mut query = names::table
@@ -174,11 +186,17 @@ pub fn get_auctions(
     if let Some(search) = search {
         query = query.filter(names::name.like(format!("%{search}%")))
     }
-    query = match status {
-        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
-        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
-        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
-    };
+    if let Some(status) = status {
+        query = match status {
+            AuctionStatus::Active => {
+                query.filter(auctions::expiration_timestamp.gt(now.timestamp()))
+            }
+            AuctionStatus::Finished => {
+                query.filter(auctions::expiration_timestamp.le(now.timestamp()))
+            }
+            AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+        };
+    }
     query = match (sort, sort_by) {
         (SortOrder::Asc, AuctionSortBy::Name) => query.order(names::name.asc()),
         (SortOrder::Desc, AuctionSortBy::Name) => query.order(names::name.desc()),
@@ -199,7 +217,7 @@ pub fn get_auctions(
 pub fn get_auctions_count(
     conn: &mut SqliteConnection,
     search: Option<&str>,
-    status: AuctionStatus,
+    status: Option<AuctionStatus>,
     now: DateTime<Utc>,
 ) -> Result<usize> {
     let mut query = names::table
@@ -208,11 +226,17 @@ pub fn get_auctions_count(
         .select(dsl::count_distinct(names::id))
         .into_boxed();
 
-    query = match status {
-        AuctionStatus::Active => query.filter(auctions::expiration_timestamp.gt(now.timestamp())),
-        AuctionStatus::Finished => query.filter(auctions::expiration_timestamp.le(now.timestamp())),
-        AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
-    };
+    if let Some(status) = status {
+        query = match status {
+            AuctionStatus::Active => {
+                query.filter(auctions::expiration_timestamp.gt(now.timestamp()))
+            }
+            AuctionStatus::Finished => {
+                query.filter(auctions::expiration_timestamp.le(now.timestamp()))
+            }
+            AuctionStatus::Claimed => query.filter(auctions::claimed.eq(true)),
+        };
+    }
 
     if let Some(search) = search {
         query = query.filter(names::name.like(format!("%{search}%")))

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -152,6 +152,7 @@ pub fn get_auctions_for_bidder_count(
     Ok(query.first::<i64>(conn)? as _)
 }
 
+#[expect(clippy::too_many_arguments)]
 pub fn get_auctions(
     conn: &mut SqliteConnection,
     page: Option<usize>,

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -38,10 +38,7 @@ use tracing::{debug, info, warn};
 use crate::{
     IotaNamesMetrics,
     config::IotaNamesExtendedConfig,
-    db::{
-        pool::DbConnectionPool,
-        queries::{add_bids_entry, get_bid_count},
-    },
+    db::{pool::DbConnectionPool, queries},
     events::{CouponKind, IotaNamesEvent},
 };
 
@@ -152,22 +149,29 @@ impl IotaNamesWorker {
                 let name_str = event.name.to_string();
                 let mut conn = self.pool.get_connection()?;
                 conn.transaction::<_, anyhow::Error, _>(|conn| {
-                    add_bids_entry(
-                        conn,
-                        &event.bidder.to_string(),
-                        &name_str,
-                        event.starting_bid,
-                    )
+                    let bidder = queries::get_or_create_bidder(conn, &event.bidder.to_string())?;
+                    let name = queries::get_or_create_name(conn, &name_str)?;
+                    queries::upsert_auctions_entry(conn, &name, event.end_timestamp_ms as _)?;
+                    queries::add_bids_entry(conn, &bidder, &name, event.starting_bid)
                 })?;
             }
             IotaNamesEvent::AuctionBid(event) => {
                 let name_str = event.name.to_string();
                 let mut conn = self.pool.get_connection()?;
                 conn.transaction::<_, anyhow::Error, _>(|conn| {
-                    add_bids_entry(conn, &event.bidder.to_string(), &name_str, event.bid)
+                    let bidder = queries::get_or_create_bidder(conn, &event.bidder.to_string())?;
+                    let name = queries::get_or_create_name(conn, &name_str)?;
+                    queries::add_bids_entry(conn, &bidder, &name, event.bid)
                 })?;
             }
-            IotaNamesEvent::AuctionExtended(_event) => (),
+            IotaNamesEvent::AuctionExtended(event) => {
+                let name_str = event.name.to_string();
+                let mut conn = self.pool.get_connection()?;
+                conn.transaction::<_, anyhow::Error, _>(|conn| {
+                    let name = queries::get_or_create_name(conn, &name_str)?;
+                    queries::upsert_auctions_entry(conn, &name, event.end_timestamp_ms as _)
+                })?;
+            }
             IotaNamesEvent::AuctionFinalized(event) => {
                 self.metrics.auctions_finalized.inc();
                 self.metrics.auction_final_prices.observe(event.winning_bid);
@@ -176,8 +180,11 @@ impl IotaNamesWorker {
                     .observe(event.end_timestamp_ms - event.start_timestamp_ms);
                 let name_str = event.name.to_string();
                 let mut conn = self.pool.get_connection()?;
-                let bid_count =
-                    conn.transaction::<_, anyhow::Error, _>(|conn| get_bid_count(conn, &name_str))?;
+                let bid_count = conn.transaction::<_, anyhow::Error, _>(|conn| {
+                    let name = queries::get_or_create_name(conn, &name_str)?;
+                    queries::claim_auctions_entry(conn, &name)?;
+                    queries::get_bid_count(conn, &name_str)
+                })?;
                 self.metrics
                     .auction_bid_count_distribution
                     .with_label_values(&[&bid_count.to_string()])


### PR DESCRIPTION
## Description

Adds a new table to track the statuses of auctions so that the API endpoints can query based on them.

Auctions can be in one of three states:
- Active
- Finished
- Claimed

Which can be queried in both auction endpoints via the `status` variable.