### PR TITLE
fix(names-display): Increase the param length from `100` (defeault) to `1000`

### DIFF
--- a/names-display/src/index.ts
+++ b/names-display/src/index.ts
@@ -13,7 +13,7 @@ export const Params = z.object({
     timestamp: z.coerce.number(),
 });
 
-const fastify = Fastify({ logger: true });
+const fastify = Fastify({ logger: true, maxParamLength: 1000 });
 
 await fastify.register(cors, {
     origin: '*',


### PR DESCRIPTION
Increase the param length from `100` (defeault) to `1000` (it could be higher if you want)
Closes https://github.com/iotaledger/iota-names/issues/583