### PR TITLE
fix: Fix RUSTSEC-2025-0047 by upgrading `slab`

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -8155,9 +8155,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slip10_ed25519"


### PR DESCRIPTION
# Description

Fixes this new advisory: https://rustsec.org/advisories/RUSTSEC-2025-0047