### PR TITLE
fix(dapp): Show auction bid spinner when there is pending data

### DIFF
--- a/dapp/src/auctions/components/dialogs/AuctionBidDialog.tsx
+++ b/dapp/src/auctions/components/dialogs/AuctionBidDialog.tsx
@@ -258,7 +258,7 @@ export function AuctionBidDialog({ name, closeDialog, onCompleted }: AuctionBidD
                                 <Button
                                     type={ButtonType.Primary}
                                     disabled={disablePlaceBid}
-                                    icon={isLoading ? <LoadingIndicator /> : null}
+                                    icon={isLoading || isPending ? <LoadingIndicator /> : null}
                                     text={auctionMetadata ? 'Bid' : 'Start auction'}
                                     onClick={() => {
                                         if (auctionBidTransaction) {


### PR DESCRIPTION
This way the spinner shows when the button is also disabled because there is still pending data