### PR TITLE
feat(scripts): add remove-move-envs script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,12 @@ This will automatically publish all the packages in the correct order, collect a
 file, as well as do a full on-chain setup (creation of the registry, addition of pricelist, authorization of all apps as well as
 calling their respective setup functions).
 
+If you want to publish (not upgrade) to a network, where an [env] entry already exists in the Move.lock files of the packages, you can run the following script to remove them, otherwise publishing will fail:
+
+```bash
+pnpm ts-node remove-move-envs.ts
+```
+
 Then, you can use these published variables to the SDK and call different actions (e.g. registering names, subnames etc)
 
 > Do not check-in the `Move.lock` and `Move.toml` changes if you are submitting a PR.

--- a/scripts/remove-move-envs.ts
+++ b/scripts/remove-move-envs.ts
@@ -1,0 +1,47 @@
+// Removes all [env] sections from Move.lock files in packages/*/
+//
+// Usage: ts-node scripts/remove-move-env.ts
+
+import fs from 'fs';
+import path from 'path';
+
+const PACKAGES_DIR = path.join(__dirname, '../packages');
+const TARGET_FILE = 'Move.lock';
+const ENV_HEADERS = ['[env]', '[env.devnet]', '[env.testnet]', '[env.mainnet]'];
+
+function findMoveLockFiles(dir: string): string[] {
+    return fs
+        .readdirSync(dir)
+        .map((pkg) => path.join(dir, pkg, TARGET_FILE))
+        .filter((f) => fs.existsSync(f));
+}
+
+function removeEnvSections(content: string): string {
+    const lines = content.split(/\r?\n/);
+    const result: string[] = [];
+    let skip = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (ENV_HEADERS.includes(line.trim())) {
+            skip = true;
+            continue;
+        }
+        if (skip && line.startsWith('[') && line.endsWith(']')) {
+            skip = false;
+        }
+        if (!skip) result.push(line);
+    }
+    return result.join('\n');
+}
+
+function processFile(filePath: string) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const cleaned = removeEnvSections(content);
+    fs.writeFileSync(filePath, cleaned, 'utf8');
+    console.log(`Cleaned: ${filePath}`);
+}
+
+const moveLockFiles = findMoveLockFiles(PACKAGES_DIR);
+moveLockFiles.forEach(processFile);
+
+console.log('Done.');


### PR DESCRIPTION
Remove script to remove env entries to make it easier to publish to networks where an entry exists already
Tested by running
```
cd scripts
iota client switch --env devnet
pnpm ts-node remove-move-envs.ts
pnpm ts-node init/init.ts devnet
```

```
Cleaned: /home/t/Desktop/iota-names/packages/auction/Move.lock
Cleaned: /home/t/Desktop/iota-names/packages/coupons/Move.lock
Cleaned: /home/t/Desktop/iota-names/packages/iota-names/Move.lock
Cleaned: /home/t/Desktop/iota-names/packages/payments/Move.lock
Cleaned: /home/t/Desktop/iota-names/packages/subnames/Move.lock
Cleaned: /home/t/Desktop/iota-names/packages/temp-subname-proxy/Move.lock
Done.
Publishing IotaNames...
...
```