### PR TITLE
fix(dapp): Use JSON RPC for the `getOwnedObjects` method

### DIFF
--- a/dapp/src/lib/utils/defaultRpcClient.ts
+++ b/dapp/src/lib/utils/defaultRpcClient.ts
@@ -26,6 +26,7 @@ export const createIotaClient = (network: NetworkId): IotaClient => {
                 'multiGetObjects',
                 'getReferenceGasPrice',
                 'getNormalizedMoveFunction',
+                'getOwnedObjects',
             ],
         }),
     });


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota-names/issues/674