### PR TITLE
fix(dapp): allow updating subnames avatars and display them correctly

### DIFF
--- a/dapp/src/components/dialogs/PersonalizeAvatarDialog.tsx
+++ b/dapp/src/components/dialogs/PersonalizeAvatarDialog.tsx
@@ -96,21 +96,29 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
                     nftId,
                     key: ALLOWED_METADATA.avatar,
                     value: action.avatar,
+                    isSubname: isNameSubname,
                 });
             } else if (action.type === 'unset' && currentAvatar) {
                 updates.push({
                     type: 'unset-data',
                     nftId,
                     key: ALLOWED_METADATA.avatar,
+                    isSubname: isNameSubname,
                 });
             }
         }
     }
 
-    const { data: updateTransaction, isLoading: isUpdating } = useUpdateNameTransaction({
+    const {
+        data: updateTransaction,
+        isLoading: isUpdating,
+        error,
+    } = useUpdateNameTransaction({
         address: account?.address || '',
         updates,
     });
+
+    const errorMessage = error ? getUserFriendlyErrorMessage(error) : null;
 
     const { mutateAsync: signAndExecuteTransaction, isPending: isSigning } =
         useSignAndExecuteTransaction();
@@ -151,7 +159,7 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
     const isLoadingData = isLoadingGetVisualAssets;
     const isLoading = isUpdating || isLoadingData || isSaving || isSigning;
     const disableUnset = !currentAvatar || isLoading || updates.length > 0;
-    const disableSave = isLoading || updates.length === 0;
+    const disableSave = isLoading || updates.length === 0 || !updateTransaction;
 
     return (
         <Dialog open onOpenChange={setOpen}>
@@ -177,6 +185,7 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
                                 </span>
                             </div>
                         </div>
+
                         {isLoadingData ? (
                             <div className="flex items-center justify-center w-full h-full py-lg">
                                 <LoadingIndicator text="Loading Assets..." />
@@ -227,6 +236,17 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
                     </div>
                 </DialogBody>
 
+                {errorMessage && (
+                    <div className="mt-auto w-full px-md--rs">
+                        <InfoBox
+                            title="Error"
+                            supportingText={errorMessage}
+                            icon={<Info />}
+                            type={InfoBoxType.Error}
+                            style={InfoBoxStyle.Elevated}
+                        />
+                    </div>
+                )}
                 <div className="flex w-full flex-row justify-center gap-2 px-md--rs pb-md--rs pt-md--rs">
                     <Button
                         type={ButtonType.Secondary}

--- a/dapp/src/components/dialogs/PersonalizeAvatarDialog.tsx
+++ b/dapp/src/components/dialogs/PersonalizeAvatarDialog.tsx
@@ -109,16 +109,10 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
         }
     }
 
-    const {
-        data: updateTransaction,
-        isLoading: isUpdating,
-        error,
-    } = useUpdateNameTransaction({
+    const { data: updateTransaction, isLoading: isUpdating } = useUpdateNameTransaction({
         address: account?.address || '',
         updates,
     });
-
-    const errorMessage = error ? getUserFriendlyErrorMessage(error) : null;
 
     const { mutateAsync: signAndExecuteTransaction, isPending: isSigning } =
         useSignAndExecuteTransaction();
@@ -236,17 +230,6 @@ export function PersonalizeAvatarDialog({ name, setOpen }: PersonalizeAvatarDial
                     </div>
                 </DialogBody>
 
-                {errorMessage && (
-                    <div className="mt-auto w-full px-md--rs">
-                        <InfoBox
-                            title="Error"
-                            supportingText={errorMessage}
-                            icon={<Info />}
-                            type={InfoBoxType.Error}
-                            style={InfoBoxStyle.Elevated}
-                        />
-                    </div>
-                )}
                 <div className="flex w-full flex-row justify-center gap-2 px-md--rs pb-md--rs pt-md--rs">
                     <Button
                         type={ButtonType.Secondary}

--- a/dapp/src/components/name-record/AvatarDisplay.tsx
+++ b/dapp/src/components/name-record/AvatarDisplay.tsx
@@ -1,12 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { isSubname } from '@iota/iota-names-sdk';
 import cx from 'clsx';
 import { useEffect, useState } from 'react';
 
 import loadingAnimationData from '@/animations/lottie-loading.json';
-import { useNameRecord, useRegistrationNfts } from '@/hooks';
+import { useNameRecord } from '@/hooks';
 import { useGetObject } from '@/hooks/useGetOwnedObject';
 
 import { LottieAnimation } from '../loaders/Lottie';
@@ -19,14 +18,10 @@ interface NameAvatarDisplay {
 
 export function NameAvatarDisplay({ name }: NameAvatarDisplay) {
     const { data: nameRecordData, isLoading: isNameRecordDataLoading } = useNameRecord(name);
-    const { data: subnames, isLoading: isSubnamesLoading } = useRegistrationNfts('subname');
-    const isNameSubname = isSubname(name);
 
     const avatarId =
         nameRecordData?.type === 'unavailable'
-            ? isNameSubname
-                ? subnames?.find((n) => n.name === name)?.id
-                : (nameRecordData?.nameRecord.avatar ?? nameRecordData.nameRecord.nftId)
+            ? (nameRecordData?.nameRecord.avatar ?? nameRecordData.nameRecord.nftId)
             : null;
 
     const { data: avatarObject, isLoading: isAvatarLoading } = useGetObject(name, {
@@ -34,14 +29,14 @@ export function NameAvatarDisplay({ name }: NameAvatarDisplay) {
         options: { showDisplay: true, showContent: true },
     });
 
-    const isDataLoading = isNameRecordDataLoading || isSubnamesLoading || isAvatarLoading;
+    const isDataLoading = isNameRecordDataLoading || isAvatarLoading;
 
     return (
         <AvatarDisplay
             src={avatarObject?.display?.data?.image_url}
             isLoadingSrc={isDataLoading}
             alt={name}
-        ></AvatarDisplay>
+        />
     );
 }
 
@@ -97,7 +92,7 @@ export function AvatarDisplay({ src, alt, isLoadingSrc }: AvatarDisplayProps) {
                         alt={alt}
                     />
                     <div className="absolute inset-0 w-full h-full flex items-center justify-center font-roboto-flex text-md font-semibold">
-                        {avatarSrc === FALLBACK_URL ? <span>Couldn’t load avatar</span> : null}
+                        {avatarSrc === FALLBACK_URL ? <span>Couldn't load avatar</span> : null}
                     </div>
                 </div>
             ) : null}

--- a/dapp/src/hooks/useUpdateNameTransaction.ts
+++ b/dapp/src/hooks/useUpdateNameTransaction.ts
@@ -22,13 +22,13 @@ export type NameUpdate =
           nftId: string;
           key: string;
           value: string;
-          isSubname?: boolean;
+          isSubname: boolean;
       }
     | {
           type: 'unset-data';
           nftId: string;
           key: string;
-          isSubname?: boolean;
+          isSubname: boolean;
       }
     | {
           type: 'set-target-address';


### PR DESCRIPTION
1. Strengthen type in name update hook, to always pass a `isSubname` flag and add it to necessary places.
2. Fix bug when fetching subnames avatar

FIxes #672 