### PR TITLE
feat(scripts): use NETWORK env instead of hardcoded networks

### DIFF
--- a/scripts/transactions/funds-to-treasury.ts
+++ b/scripts/transactions/funds-to-treasury.ts
@@ -17,14 +17,20 @@ if (args.length !== 1) {
 
 const treasuryAddress = args[0]; // First argument should be treasury address
 
-// TODO provide network parameter
 const craftTx = async () => {
-    const txb = new Transaction();
-    const packageInfo = readPackageInfo('devnet');
+    const network = process.env.NETWORK;
+    if (!network) {
+        throw new Error(
+            'Network not defined. Please run `export NETWORK=mainnet|testnet|devnet|localnet`',
+        );
+    }
 
+    const packageInfo = readPackageInfo(network);
+
+    const txb = new Transaction();
     profitsToTreasury(txb, packageInfo, treasuryAddress);
 
-    await prepareMultisigTx(txb, 'devnet', packageInfo.adminAddress);
+    await prepareMultisigTx(txb, network, packageInfo.adminAddress);
 };
 
 craftTx();

--- a/scripts/transactions/transfer-admin-objects.ts
+++ b/scripts/transactions/transfer-admin-objects.ts
@@ -17,10 +17,15 @@ if (args.length !== 1) {
 }
 const newAddress = args[0]; // First argument should be new address
 
-const network = 'localnet';
-const packageInfo = readPackageInfo(network);
-
 const treasuryClaimAndMoveCapsToFoundation = async () => {
+    const network = process.env.NETWORK;
+    if (!network) {
+        throw new Error(
+            'Network not defined. Please run `export NETWORK=mainnet|testnet|devnet|localnet`',
+        );
+    }
+    const packageInfo = readPackageInfo(network);
+
     const client = getClient(network);
 
     const objectsToTransfer = await getIotaNamesAdminObjects(packageInfo, client);
@@ -28,7 +33,6 @@ const treasuryClaimAndMoveCapsToFoundation = async () => {
     console.log(objectsToTransfer);
 
     const txb = new Transaction();
-
     profitsToTreasury(txb, packageInfo, newAddress);
 
     txb.transferObjects(objectsToTransfer, txb.pure.address(newAddress));


### PR DESCRIPTION
Use NETWORK env instead of hardcoded networks so the scripts can be used for different networks witout adjusting them before
In iota-names-build-tx.yaml the network env already gets set, so no change needed there

Fixes https://github.com/iotaledger/iota-names/issues/612


