### PR TITLE
fix(dapp): Invalidate default name after purchase

### DIFF
--- a/dapp/src/components/dialogs/PurchaseNameDialog.tsx
+++ b/dapp/src/components/dialogs/PurchaseNameDialog.tsx
@@ -135,6 +135,9 @@ export function PurchaseNameDialog({ name, open, setOpen, onPurchase }: Purchase
             queryClient.removeQueries({
                 queryKey: queryKey.nameRecord(name),
             });
+            queryClient.invalidateQueries({
+                queryKey: queryKey.defaultName(account?.address || ''),
+            });
             toast.success(
                 `Successfully registered name ${normalizeIotaName(name, 'at', { truncateLongParts: true })}`,
             );


### PR DESCRIPTION
This way the "Displayed" label gets updated after purchasing a name which is also going to be set as Displayed