### PR TITLE
fix(dapp): Close availability check dialog after connecting wallet after accepting TOS

### DIFF
--- a/dapp/src/components/buttons/ConnectButton.tsx
+++ b/dapp/src/components/buttons/ConnectButton.tsx
@@ -7,13 +7,16 @@ import { ConnectButton as DappConnectButton } from '@iota/dapp-kit';
 import { useRouter } from 'next/navigation';
 
 import { TermsAndConds } from '@/lib/utils/termsAndConditions';
+import { useAvailabilityCheckDialog } from '@/stores/useAvailabilityCheckDialog';
 
 export function ConnectButton() {
+    const { close } = useAvailabilityCheckDialog();
     const router = useRouter();
 
     function handleClick(ev: React.MouseEvent) {
         const areTermsAndConditionsAccepted = TermsAndConds.areAccepted();
         if (!areTermsAndConditionsAccepted) {
+            close();
             // Prevent the dapp kit modal from opening
             ev.preventDefault();
             ev.stopPropagation();


### PR DESCRIPTION
Reproduce issue outside of this pr:
- disconnect
- clear local storage
- go to availability dialog
- try to buy/bid -> connect
- accept tos
- connect
- the whole dapp is now frozen

With this PR the last step doesnt occur

The issue was that internally radix still thought the availability dialog was open