### PR TITLE
feat(payment): add init_registration_with_years()

### DIFF
--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -564,7 +564,7 @@ fun test_coupon_register(
     name: String,
     coupon_code: String,
     user: address,
-    amount: Option<u64>, // optional param to test for expected amount
+    mut amount: Option<u64>, // optional param to test for expected amount
 ) {
     scenario.next_tx(user);
     {
@@ -582,7 +582,7 @@ fun test_coupon_register(
             scenario.ctx(),
         );
         if (amount.is_some()) {
-            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+            assert!(intent.request_data().base_amount() == amount.extract());
         };
 
         return_shared(iota_names);
@@ -596,7 +596,7 @@ fun test_multi_coupon_register(
     name: String,
     mut coupon_codes: vector<String>,
     user: address,
-    amount: Option<u64>, // optional param to test for expected amount
+    mut amount: Option<u64>, // optional param to test for expected amount
 ) {
     scenario.next_tx(user);
     {
@@ -617,7 +617,7 @@ fun test_multi_coupon_register(
             );
         };
         if (amount.is_some()) {
-            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+            assert!(intent.request_data().base_amount() == amount.extract());
         };
 
         return_shared(iota_names);
@@ -632,7 +632,7 @@ fun test_coupon_renewal(
     renewal_years: u8,
     coupon_code: String,
     user: address,
-    amount: Option<u64>, // optional param to test for expected amount
+    mut amount: Option<u64>, // optional param to test for expected amount
 ) {
     scenario.next_tx(user);
     {
@@ -658,7 +658,7 @@ fun test_coupon_renewal(
             scenario.ctx(),
         );
         if (amount.is_some()) {
-            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+            assert!(intent.request_data().base_amount() == amount.extract());
         };
 
         return_shared(iota_names);
@@ -797,7 +797,7 @@ fun test_coupon_multi_year_register(
     years: u8,
     coupon_code: String,
     user: address,
-    amount: Option<u64>, // optional param to test for expected amount
+    mut amount: Option<u64>, // optional param to test for expected amount
 ) {
     scenario.next_tx(user);
     {
@@ -816,7 +816,7 @@ fun test_coupon_multi_year_register(
             scenario.ctx(),
         );
         if (amount.is_some()) {
-            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+            assert!(intent.request_data().base_amount() == amount.extract());
         };
 
         return_shared(iota_names);
@@ -831,7 +831,7 @@ fun test_multi_coupon_multi_year_register(
     years: u8,
     mut coupon_codes: vector<String>,
     user: address,
-    amount: Option<u64>, // optional param to test for expected amount
+    mut amount: Option<u64>, // optional param to test for expected amount
 ) {
     scenario.next_tx(user);
     {
@@ -853,7 +853,7 @@ fun test_multi_coupon_multi_year_register(
             );
         };
         if (amount.is_some()) {
-            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+            assert!(intent.request_data().base_amount() == amount.extract());
         };
 
         return_shared(iota_names);

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -685,6 +685,190 @@ fun init_renewal(
 }
 
 #[test]
+fun test_coupon_multi_year_registration() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    populate_coupons(scenario);
+
+    // Test 25% discount on 2-year registration (within max 2 years limit)
+    // Base price for 4-char name: 200 (registration) + 200*1 (renewal) = 400
+    // 25% discount: 400 * 0.75 = 300
+    test_coupon_multi_year_register(
+        scenario,
+        b"test.iota".to_string(),
+        2,
+        b"25_PERCENT_DISCOUNT_MAX_2_YEARS".to_string(),
+        user(),
+        option::some(300 * nanos_per_iota()),
+    );
+
+    // Test 50% discount on 2-year registration for 5+ character name
+    // Base price: 50 (registration) + 50*1 (renewal) = 100
+    // 50% discount: 100 * 0.5 = 50
+    test_coupon_multi_year_register(
+        scenario,
+        b"testo.iota".to_string(),
+        2,
+        b"50_PERCENT_5_PLUS_NAMES".to_string(),
+        user(),
+        option::some(50 * nanos_per_iota()),
+    );
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_coupon_multi_year_registration_stackable() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    populate_coupons(scenario);
+
+    // Add a stackable percentage discount
+    admin_add_percentage_coupon(
+        b"10_PERCENT_STACKABLE".to_string(),
+        10,
+        scenario,
+    );
+
+    // Test stacking two coupons on 2-year registration
+    // Base price for 4-char name: 200 (registration) + 200*1 (renewal) = 400
+    // First apply 5% discount: 400 * 0.95 = 380
+    // Then apply 10% discount: 380 * 0.9 = 342
+    test_multi_coupon_multi_year_register(
+        scenario,
+        b"test.iota".to_string(),
+        2,
+        vector[b"5_DISCOUNT_STACKABLE".to_string(), b"10_PERCENT_STACKABLE".to_string()],
+        user(),
+        option::some(342 * nanos_per_iota()),
+    );
+
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::iota_names_coupons::rules::EInvalidYears)]
+fun test_coupon_multi_year_invalid_years() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    populate_coupons(scenario);
+
+    // Try to use a coupon that only allows 1-2 years for a 3-year registration
+    test_coupon_multi_year_register(
+        scenario,
+        b"test.iota".to_string(),
+        3,
+        b"25_PERCENT_DISCOUNT_MAX_2_YEARS".to_string(),
+        user(),
+        option::none(),
+    );
+
+    scenario_val.end();
+}
+
+#[test]
+fun test_coupon_multi_year_zero_fee() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    populate_coupons(scenario);
+
+    // Add a 100% discount coupon
+    admin_add_percentage_coupon(
+        b"100_PERCENT_OFF".to_string(),
+        100,
+        scenario,
+    );
+
+    // Test 100% discount on 4-year registration should result in 0 cost
+    test_coupon_multi_year_register(
+        scenario,
+        b"test.iota".to_string(),
+        4,
+        b"100_PERCENT_OFF".to_string(),
+        user(),
+        option::some(0),
+    );
+
+    scenario_val.end();
+}
+
+fun test_coupon_multi_year_register(
+    scenario: &mut Scenario,
+    name: String,
+    years: u8,
+    coupon_code: String,
+    user: address,
+    amount: Option<u64>, // optional param to test for expected amount
+) {
+    scenario.next_tx(user);
+    {
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let mut intent = init_registration_with_years(
+            &mut iota_names,
+            name,
+            years,
+        );
+        let clock = scenario.take_shared<Clock>();
+        coupon_house::apply_coupon(
+            &mut intent,
+            &mut iota_names,
+            coupon_code,
+            &clock,
+            scenario.ctx(),
+        );
+        if (amount.is_some()) {
+            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+        };
+
+        return_shared(iota_names);
+        return_shared(clock);
+        destroy(intent);
+    };
+}
+
+fun test_multi_coupon_multi_year_register(
+    scenario: &mut Scenario,
+    name: String,
+    years: u8,
+    mut coupon_codes: vector<String>,
+    user: address,
+    amount: Option<u64>, // optional param to test for expected amount
+) {
+    scenario.next_tx(user);
+    {
+        let mut iota_names = scenario.take_shared<IotaNames>();
+        let mut intent = init_registration_with_years(
+            &mut iota_names,
+            name,
+            years,
+        );
+        let clock = scenario.take_shared<Clock>();
+        while (!coupon_codes.is_empty()) {
+            let coupon_code = coupon_codes.pop_back();
+            coupon_house::apply_coupon(
+                &mut intent,
+                &mut iota_names,
+                coupon_code,
+                &clock,
+                scenario.ctx(),
+            );
+        };
+        if (amount.is_some()) {
+            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
+        };
+
+        return_shared(iota_names);
+        return_shared(clock);
+        destroy(intent);
+    };
+}
+
+fun init_registration_with_years(iota_names: &mut IotaNames, name: String, years: u8): PaymentIntent {
+    let intent = iota_names::payment::init_registration_with_years(iota_names, name, years);
+
+    intent
+}
+
+#[test]
 fun test_coupon_getters() {
     let rules = rules::new_coupon_rules(option::none(), option::none(), option::none(), option::none(), option::none(), false);
     let percentage_coupon = coupon::new_percentage(25, rules);

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -50,6 +50,8 @@ const EVersionMismatch: vector<u8> =
 const ECannotRenewSubname: vector<u8> = b"Cannot renew a subname using the payment system.";
 #[error]
 const ECannotExceedMaxYears: vector<u8> = b"Cannot exceed the maximum number of years.";
+#[error]
+const EYearsMustBePositive: vector<u8> = b"Years must be greater than zero.";
 
 /// The data required to complete a payment request.
 public struct RequestData has drop {
@@ -153,6 +155,7 @@ public fun init_registration(iota_names: &mut IotaNames, name: String): PaymentI
 public fun init_registration_with_years(iota_names: &mut IotaNames, name: String, years: u8): PaymentIntent {
     let name = name::new(name);
     validation::assert_is_valid_for_sale(iota_names.get_config<CoreConfig>(), iota_names, &name);
+    assert!(years > 0, EYearsMustBePositive);
     assert!(years <= iota_names.get_config<CoreConfig>().max_years(), ECannotExceedMaxYears);
 
     // Calculate price for first year using registration pricing
@@ -188,6 +191,7 @@ public fun init_renewal(
 ): PaymentIntent {
     let name = nft.name();
     assert!(!name.is_subname(), ECannotRenewSubname);
+    assert!(years > 0, EYearsMustBePositive);
     assert!(years <= iota_names.get_config<CoreConfig>().max_years(), ECannotExceedMaxYears);
 
     let price = iota_names

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -153,25 +153,25 @@ public fun init_registration(iota_names: &mut IotaNames, name: String): PaymentI
 /// Creates a `PaymentIntent` for registering a new name for multiple years.
 /// This is a hot-potato and can only be consumed in a single transaction.
 public fun init_registration_with_years(iota_names: &mut IotaNames, name: String, years: u8): PaymentIntent {
+    assert!(years > 0, EYearsMustBePositive);
+    if (years == 1) {
+        return init_registration(iota_names, name)
+    };
+
     let name = name::new(name);
     validation::assert_is_valid_for_sale(iota_names.get_config<CoreConfig>(), iota_names, &name);
-    assert!(years > 0, EYearsMustBePositive);
     assert!(years <= iota_names.get_config<CoreConfig>().max_years(), ECannotExceedMaxYears);
 
-    // Calculate price for first year using registration pricing
+    // Use PricingConfig for the first year
     let registration_price = iota_names.get_config<PricingConfig>().calculate_base_price_of_name(name);
     
-    // Calculate price for additional years using renewal pricing
-    let total_price = if (years == 1) {
-        registration_price
-    } else {
-        let renewal_price = iota_names
+    // Calculate price for additional years with the RenewalConfig
+    let renewal_price = iota_names
             .get_config<RenewalConfig>()
             .config()
             .calculate_base_price_of_name(name);
         
-        registration_price + (renewal_price * ((years - 1) as u64))
-    };
+    let total_price = registration_price + (renewal_price * ((years - 1) as u64));
 
     PaymentIntent::Registration(RequestData {
         name,

--- a/packages/iota-names/sources/sales/payment.move
+++ b/packages/iota-names/sources/sales/payment.move
@@ -148,6 +148,37 @@ public fun init_registration(iota_names: &mut IotaNames, name: String): PaymentI
     })
 }
 
+/// Creates a `PaymentIntent` for registering a new name for multiple years.
+/// This is a hot-potato and can only be consumed in a single transaction.
+public fun init_registration_with_years(iota_names: &mut IotaNames, name: String, years: u8): PaymentIntent {
+    let name = name::new(name);
+    validation::assert_is_valid_for_sale(iota_names.get_config<CoreConfig>(), iota_names, &name);
+    assert!(years <= iota_names.get_config<CoreConfig>().max_years(), ECannotExceedMaxYears);
+
+    // Calculate price for first year using registration pricing
+    let registration_price = iota_names.get_config<PricingConfig>().calculate_base_price_of_name(name);
+    
+    // Calculate price for additional years using renewal pricing
+    let total_price = if (years == 1) {
+        registration_price
+    } else {
+        let renewal_price = iota_names
+            .get_config<RenewalConfig>()
+            .config()
+            .calculate_base_price_of_name(name);
+        
+        registration_price + (renewal_price * ((years - 1) as u64))
+    };
+
+    PaymentIntent::Registration(RequestData {
+        name,
+        years,
+        base_amount: total_price,
+        metadata: vec_map::empty(),
+        version: constants::payments_version!(),
+    })
+}
+
 /// Creates a `PaymentIntent` for renewing an existing name.
 /// This is a hot-potato and can only be consumed in a single transaction.
 public fun init_renewal(

--- a/packages/iota-names/tests/payments/payment_tests.move
+++ b/packages/iota-names/tests/payments/payment_tests.move
@@ -483,6 +483,15 @@ fun test_e2e_multi_year_registration() {
     destroy(clock);
 }
 
+#[test, expected_failure(abort_code = ::iota_names::payment::EYearsMustBePositive)]
+fun test_init_registration_with_zero_years() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+    let name = b"test.iota".to_string();
+    let _intent = payment::init_registration_with_years(&mut iota_names, name, 0);
+    abort 1337
+}
+
 public fun setup_iota_names(ctx: &mut TxContext): IotaNames {
     let (mut iota_names, cap) = iota_names::new_for_testing(ctx);
 

--- a/packages/iota-names/tests/payments/payment_tests.move
+++ b/packages/iota-names/tests/payments/payment_tests.move
@@ -382,6 +382,107 @@ fun test_calculate_total_after_discount() {
     destroy(iota_names);
 }
 
+#[test]
+fun test_init_registration_with_years() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+    let clock = clock::create_for_testing(&mut ctx);
+
+    let name = b"test.iota".to_string();
+
+    // Test 1 year registration (should be same as normal registration)
+    let intent_1_year = payment::init_registration_with_years(&mut iota_names, name, 1);
+    assert_eq(intent_1_year.request_data().base_amount(), 100); // registration price for 4-char name
+    assert_eq(intent_1_year.request_data().years(), 1);
+
+    // Test 3 year registration (1 year registration + 2 years renewal)
+    // Registration: 100, Renewal: 10 per year, so total = 100 + (10 * 2) = 120
+    let intent_3_years = payment::init_registration_with_years(&mut iota_names, name, 3);
+    assert_eq(intent_3_years.request_data().base_amount(), 120);
+    assert_eq(intent_3_years.request_data().years(), 3);
+
+    // Test 5 year registration (1 year registration + 4 years renewal)
+    // Registration: 100, Renewal: 10 per year, so total = 100 + (10 * 4) = 140
+    let intent_5_years = payment::init_registration_with_years(&mut iota_names, name, 5);
+    assert_eq(intent_5_years.request_data().base_amount(), 140);
+    assert_eq(intent_5_years.request_data().years(), 5);
+
+    // Clean up
+    destroy(intent_1_year);
+    destroy(intent_3_years);
+    destroy(intent_5_years);
+    destroy(iota_names);
+    destroy(clock);
+}
+
+#[test]
+fun test_init_registration_with_years_different_name_lengths() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+    let clock = clock::create_for_testing(&mut ctx);
+
+    // Test 3-character name for 2 years
+    // Registration: 500, Renewal: 50 per year, so total = 500 + (50 * 1) = 550
+    let intent_3_char = payment::init_registration_with_years(&mut iota_names, b"abc.iota".to_string(), 2);
+    assert_eq(intent_3_char.request_data().base_amount(), 550);
+    assert_eq(intent_3_char.request_data().years(), 2);
+
+    // Test 5+ character name for 3 years
+    // Registration: 20, Renewal: 2 per year, so total = 20 + (2 * 2) = 24
+    let intent_5_char = payment::init_registration_with_years(&mut iota_names, b"testing.iota".to_string(), 3);
+    assert_eq(intent_5_char.request_data().base_amount(), 24);
+    assert_eq(intent_5_char.request_data().years(), 3);
+
+    // Clean up
+    destroy(intent_3_char);
+    destroy(intent_5_char);
+    destroy(iota_names);
+    destroy(clock);
+}
+
+#[test, expected_failure(abort_code = ::iota_names::payment::ECannotExceedMaxYears)]
+fun test_init_registration_with_years_exceed_max() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+
+    let name = b"test.iota".to_string();
+
+    // Try to register for 6 years (max is 5)
+    let _intent = payment::init_registration_with_years(&mut iota_names, name, 6);
+
+    abort 1337
+}
+
+#[test]
+fun test_e2e_multi_year_registration() {
+    let mut ctx = tx_context::dummy();
+    let mut iota_names = setup_iota_names(&mut ctx);
+    let clock = clock::create_for_testing(&mut ctx);
+
+    let name = b"test.iota".to_string();
+
+    // Register for 3 years using the new function
+    let intent = payment::init_registration_with_years(&mut iota_names, name, 3);
+    assert_eq(intent.request_data().base_amount(), 120); // 100 + (10 * 2)
+    assert_eq(intent.request_data().years(), 3);
+
+    // Complete the payment
+    let receipt = handle_payment(intent, &mut iota_names, &mut ctx);
+
+    // Register the name
+    let nft = receipt.register(&mut iota_names, &clock, &mut ctx);
+
+    // Verify the NFT was created with correct details
+    assert_eq(nft.name_str(), name);
+    // Should expire in exactly 3 years
+    assert_eq(nft.expiration_timestamp_ms(), constants::year_ms() * 3);
+
+    // Clean up
+    destroy(iota_names);
+    destroy(nft);
+    destroy(clock);
+}
+
 public fun setup_iota_names(ctx: &mut TxContext): IotaNames {
     let (mut iota_names, cap) = iota_names::new_for_testing(ctx);
 


### PR DESCRIPTION
Add a new init_registration_with_years() where one can register directly for multiple years. This was requested so coupons for multiple years can be used for the initial year and renewals, before this was not possible, as a coupon can only applied to a single PaymentIntent and renewal created a second one.

Fixes https://github.com/iotaledger/iota-names/issues/762

Tested with the added tests