### PR TITLE
feat(packages): Add lookup methods that check expiration

### DIFF
--- a/packages/iota-names/Move.lock
+++ b/packages/iota-names/Move.lock
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.5.0-rc"
+compiler-version = "1.6.1-rc"
 edition = "2024"
 flavor = "iota"
 

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -342,10 +342,41 @@ public fun lookup(self: &Registry, name: Name): Option<NameRecord> {
     }
 }
 
+/// Returns the `NameRecord` associated with the given name and ensures that it is not expired,
+/// or None otherwise.
+public fun lookup_verified(self: &Registry, name: Name, clock: &Clock): Option<NameRecord> {
+    if (self.registry.contains(name)) {
+        let record = &self.registry[name];
+
+        // Check that name has not expired.
+        assert!(!record.has_expired(clock), ERecordExpired);
+
+        some(*record)
+    } else {
+        none()
+    }
+}
+
 /// Returns the `name` associated with the given address or None.
 public fun reverse_lookup(self: &Registry, address: address): Option<Name> {
     if (self.reverse_registry.contains(address)) {
         some(self.reverse_registry[address])
+    } else {
+        none()
+    }
+}
+
+/// Returns the `name` associated with the given address and ensures it is not expired,
+/// or None otherwise.
+public fun reverse_lookup_verified(self: &Registry, address: address, clock: &Clock): Option<Name> {
+    if (self.reverse_registry.contains(address)) {
+        let name = self.reverse_registry[address];
+        let record = &self.registry[name];
+
+        // Check that name has not expired.
+        assert!(!record.has_expired(clock), ERecordExpired);
+
+        some(name)
     } else {
         none()
     }

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -366,10 +366,12 @@ public fun lookup_address(self: &Registry, name: Name, clock: &Clock): Option<ad
     }
 }
 
-/// Returns the address associated with the given name if one is set and the record is not expired,
-/// or None otherwise. This function is callable from PTBs unlike `lookup_address`.
-public fun resolve_address(iota_names: &IotaNames, name: Name, clock: &Clock): Option<address> {
-    iota_names.registry<Registry>().lookup_address(name, clock)
+/// Returns the address associated with the given name if one is set and the record is not expired. 
+/// This function is callable from PTBs unlike `lookup_address`.
+public fun resolve_address(iota_names: &IotaNames, name: Name, clock: &Clock): address {
+    let mut address = iota_names.registry<Registry>().lookup_address(name, clock);
+    assert!(address.is_some(), ERecordNotFound);
+    address.extract()
 }
 
 /// Returns the `name` associated with the given address or None.

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -345,13 +345,24 @@ public fun lookup(self: &Registry, name: Name): Option<NameRecord> {
 /// Returns the `NameRecord` associated with the given name and ensures that it is not expired,
 /// or None otherwise.
 public fun lookup_verified(self: &Registry, name: Name, clock: &Clock): Option<NameRecord> {
+    let record = self.lookup(name);
+    if (record.is_some()) {
+        // Check that name has not expired.
+        assert!(!record.borrow().has_expired(clock), ERecordExpired);
+    };
+    record
+}
+
+/// Returns the address associated with the given name if one is set and the record is not expired,
+/// or None otherwise.
+public fun lookup_address(self: &Registry, name: Name, clock: &Clock): Option<address> {
     if (self.registry.contains(name)) {
         let record = &self.registry[name];
 
         // Check that name has not expired.
         assert!(!record.has_expired(clock), ERecordExpired);
 
-        some(*record)
+        record.target_address()
     } else {
         none()
     }

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -546,7 +546,7 @@ fun handle_invalidate_reverse_record(
 // === Test Functions ===
 
 #[test_only]
-use iota_names::iota_names::{add_registry, IotaNames};
+use iota_names::iota_names::add_registry;
 
 #[test_only]
 public fun init_for_testing(cap: &AdminCap, iota_names: &mut IotaNames, ctx: &mut TxContext) {

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -332,11 +332,15 @@ public fun has_record(self: &Registry, name: Name): bool {
     self.registry.contains(name)
 }
 
+/// Checks whether the given `name` is registered in the `Registry`.
+public fun has_unexpired_record(self: &Registry, name: Name, clock: &Clock): bool {
+    self.registry.contains(name) && !self.registry[name].has_expired(clock)
+}
+
 /// Returns the `NameRecord` associated with the given name or None.
 public fun lookup(self: &Registry, name: Name): Option<NameRecord> {
-    if (self.registry.contains(name)) {
-        let record = &self.registry[name];
-        some(*record)
+    if (self.has_record(name)) {
+        some(self.registry[name])
     } else {
         none()
     }
@@ -344,25 +348,19 @@ public fun lookup(self: &Registry, name: Name): Option<NameRecord> {
 
 /// Returns the `NameRecord` associated with the given name and ensures that it is not expired,
 /// or None otherwise.
-public fun lookup_verified(self: &Registry, name: Name, clock: &Clock): Option<NameRecord> {
-    let record = self.lookup(name);
-    if (record.is_some()) {
-        // Check that name has not expired.
-        assert!(!record.borrow().has_expired(clock), ERecordExpired);
-    };
-    record
+public fun lookup_unexpired(self: &Registry, name: Name, clock: &Clock): Option<NameRecord> {
+    if (self.has_unexpired_record(name, clock)) {
+        some(self.registry[name])
+    } else {
+        none()
+    }
 }
 
 /// Returns the address associated with the given name if one is set and the record is not expired,
 /// or None otherwise.
 public fun lookup_address(self: &Registry, name: Name, clock: &Clock): Option<address> {
-    if (self.registry.contains(name)) {
-        let record = &self.registry[name];
-
-        // Check that name has not expired.
-        assert!(!record.has_expired(clock), ERecordExpired);
-
-        record.target_address()
+    if (self.has_unexpired_record(name, clock)) {
+        self.registry[name].target_address()
     } else {
         none()
     }
@@ -379,13 +377,13 @@ public fun reverse_lookup(self: &Registry, address: address): Option<Name> {
 
 /// Returns the `name` associated with the given address and ensures it is not expired,
 /// or None otherwise.
-public fun reverse_lookup_verified(self: &Registry, address: address, clock: &Clock): Option<Name> {
+public fun reverse_lookup_unexpired(self: &Registry, address: address, clock: &Clock): Option<Name> {
     if (self.reverse_registry.contains(address)) {
         let name = self.reverse_registry[address];
-        let record = &self.registry[name];
 
-        // Check that name has not expired.
-        assert!(!record.has_expired(clock), ERecordExpired);
+        if (self.registry[name].has_expired(clock)) {
+            return none();
+        };
 
         some(name)
     } else {

--- a/packages/iota-names/sources/registry.move
+++ b/packages/iota-names/sources/registry.move
@@ -9,7 +9,7 @@ use iota::clock::Clock;
 use iota::table::{Self, Table};
 use iota::vec_map::VecMap;
 use iota_names::name::Name;
-use iota_names::iota_names::AdminCap;
+use iota_names::iota_names::{AdminCap, IotaNames};
 use iota_names::name_registration::{Self as nft, NameRegistration};
 use iota_names::name_record::{Self, NameRecord};
 use iota_names::subname_registration::{Self, SubnameRegistration};
@@ -366,6 +366,12 @@ public fun lookup_address(self: &Registry, name: Name, clock: &Clock): Option<ad
     }
 }
 
+/// Returns the address associated with the given name if one is set and the record is not expired,
+/// or None otherwise. This function is callable from PTBs unlike `lookup_address`.
+public fun resolve_address(iota_names: &IotaNames, name: Name, clock: &Clock): Option<address> {
+    iota_names.registry<Registry>().lookup_address(name, clock)
+}
+
 /// Returns the `name` associated with the given address or None.
 public fun reverse_lookup(self: &Registry, address: address): Option<Name> {
     if (self.reverse_registry.contains(address)) {
@@ -382,7 +388,7 @@ public fun reverse_lookup_unexpired(self: &Registry, address: address, clock: &C
         let name = self.reverse_registry[address];
 
         if (self.registry[name].has_expired(clock)) {
-            return none();
+            return none()
         };
 
         some(name)

--- a/packages/iota-names/tests/unit/registry_tests.move
+++ b/packages/iota-names/tests/unit/registry_tests.move
@@ -327,7 +327,7 @@ fun set_target_address() {
     registry.set_target_address(name, some(@0x2));
 
     // try to find a record and then get a record
-    let mut search = registry.lookup(name);
+    let mut search = registry.lookup_verified(name, &clock);
     let record = registry.remove_record_for_testing(name);
 
     // make sure the search is a success
@@ -355,7 +355,7 @@ fun set_reverse_lookup() {
     registry.set_reverse_lookup(@0xB0B, name);
 
     // search for the reverse_lookup record
-    let mut search = registry::reverse_lookup(&registry, @0xB0B);
+    let mut search = registry.reverse_lookup_verified(@0xB0B, &clock);
 
     assert!(option::is_some(&search), 0);
     assert!(option::extract(&mut search) == name, 0);
@@ -827,6 +827,40 @@ fun test_lookup_nonexistent() {
     wrapup(registry, clock);
 }
 
+#[test, expected_failure(abort_code = iota_names::registry::ERecordExpired)]
+fun test_lookup_expired() {
+    let mut ctx = tx_context::dummy();
+    let (mut registry, mut clock, _name) = setup(&mut ctx);
+
+    let expired_name = name::new(utf8(b"expired.iota"));
+    let nft = registry.add_record(expired_name, 1, &clock, &mut ctx);
+
+    // Move time forward so record expires
+    clock::increment_for_testing(&mut clock, constants::year_ms() + 1);
+    
+    registry.lookup_verified(expired_name, &clock);
+
+    burn_nfts(vector[nft]);
+    wrapup(registry, clock);
+}
+
+#[test, expected_failure(abort_code = iota_names::registry::ERecordExpired)]
+fun test_lookup_address_expired() {
+    let mut ctx = tx_context::dummy();
+    let (mut registry, mut clock, _name) = setup(&mut ctx);
+
+    let expired_name = name::new(utf8(b"expired.iota"));
+    let nft = registry.add_record(expired_name, 1, &clock, &mut ctx);
+
+    // Move time forward so record expires
+    clock::increment_for_testing(&mut clock, constants::year_ms() + 1);
+    
+    registry.lookup_address(expired_name, &clock);
+
+    burn_nfts(vector[nft]);
+    wrapup(registry, clock);
+}
+
 #[test]
 fun test_reverse_lookup_nonexistent() {
     let mut ctx = tx_context::dummy();
@@ -848,13 +882,13 @@ fun test_unset_target_address() {
     
     // Set a target address first
     registry.set_target_address(name, some(@0x123));
-    let record = registry.lookup(name).destroy_some();
-    assert_eq(record.target_address(), some(@0x123));
+    let target_address = registry.lookup_address(name, &clock);
+    assert_eq(target_address, some(@0x123));
 
     // Now unset it
     registry.set_target_address(name, none());
-    let record = registry.lookup(name).destroy_some();
-    assert_eq(record.target_address(), none());
+    let target_address = registry.lookup_address(name, &clock);
+    assert_eq(target_address, none());
 
     let _ = registry.remove_record_for_testing(name);
     burn_nfts(vector[nft]);

--- a/packages/iota-names/tests/unit/registry_tests.move
+++ b/packages/iota-names/tests/unit/registry_tests.move
@@ -327,7 +327,7 @@ fun set_target_address() {
     registry.set_target_address(name, some(@0x2));
 
     // try to find a record and then get a record
-    let mut search = registry.lookup_verified(name, &clock);
+    let mut search = registry.lookup_unexpired(name, &clock);
     let record = registry.remove_record_for_testing(name);
 
     // make sure the search is a success
@@ -355,7 +355,7 @@ fun set_reverse_lookup() {
     registry.set_reverse_lookup(@0xB0B, name);
 
     // search for the reverse_lookup record
-    let mut search = registry.reverse_lookup_verified(@0xB0B, &clock);
+    let mut search = registry.reverse_lookup_unexpired(@0xB0B, &clock);
 
     assert!(option::is_some(&search), 0);
     assert!(option::extract(&mut search) == name, 0);
@@ -827,7 +827,7 @@ fun test_lookup_nonexistent() {
     wrapup(registry, clock);
 }
 
-#[test, expected_failure(abort_code = iota_names::registry::ERecordExpired)]
+#[test]
 fun test_lookup_expired() {
     let mut ctx = tx_context::dummy();
     let (mut registry, mut clock, _name) = setup(&mut ctx);
@@ -838,24 +838,32 @@ fun test_lookup_expired() {
     // Move time forward so record expires
     clock::increment_for_testing(&mut clock, constants::year_ms() + 1);
     
-    registry.lookup_verified(expired_name, &clock);
+    assert!(registry.lookup_unexpired(expired_name, &clock).is_none());
+    assert!(registry.lookup_address(expired_name, &clock).is_none());
+
+    let _ = registry.remove_record_for_testing(expired_name);
 
     burn_nfts(vector[nft]);
     wrapup(registry, clock);
 }
 
-#[test, expected_failure(abort_code = iota_names::registry::ERecordExpired)]
-fun test_lookup_address_expired() {
+#[test]
+fun test_reverse_lookup_expired() {
     let mut ctx = tx_context::dummy();
     let (mut registry, mut clock, _name) = setup(&mut ctx);
 
     let expired_name = name::new(utf8(b"expired.iota"));
     let nft = registry.add_record(expired_name, 1, &clock, &mut ctx);
+    registry.set_target_address(expired_name, some(@0xB0B));
+    registry.set_reverse_lookup(@0xB0B, expired_name);
 
     // Move time forward so record expires
     clock::increment_for_testing(&mut clock, constants::year_ms() + 1);
     
-    registry.lookup_address(expired_name, &clock);
+    assert!(registry.reverse_lookup_unexpired(@0xB0B, &clock).is_none());
+
+    registry.unset_reverse_lookup(@0xB0B);
+    let _ = registry.remove_record_for_testing(expired_name);
 
     burn_nfts(vector[nft]);
     wrapup(registry, clock);


### PR DESCRIPTION
## Description

Adds the `lookup_unexpired`, `lookup_address`, `resolve_address`, and `reverse_lookup_unexpired` functions to the `iota-names::registry` module, which check if the record is expired before returning anything.

Closes #768