### PR TITLE
chore(packages): Improve error message when new subname does not match parent

### DIFF
--- a/packages/subnames/sources/config.move
+++ b/packages/subnames/sources/config.move
@@ -64,10 +64,10 @@ public fun new(
 
 /// Validates that the child name is a valid child for parent.
 public fun assert_is_valid_subname(parent: &Name, child: &Name, config: &SubnameConfig) {
+    assert!(is_parent_of(parent, child), EInvalidParent);
     assert!(is_valid_tln(child, config), ENotSupportedTLN);
     assert!(is_valid_label(child, config), EInvalidLabelSize);
     assert!(has_valid_depth(child, config), EDepthExceedsLimit);
-    assert!(is_parent_of(parent, child), EInvalidParent);
 }
 
 /// Returns the configured minimum duration for a subname in milliseconds.

--- a/packages/subnames/sources/config.move
+++ b/packages/subnames/sources/config.move
@@ -64,9 +64,9 @@ public fun new(
 
 /// Validates that the child name is a valid child for parent.
 public fun assert_is_valid_subname(parent: &Name, child: &Name, config: &SubnameConfig) {
+    assert!(is_valid_label(child, config), EInvalidLabelSize);
     assert!(is_parent_of(parent, child), EInvalidParent);
     assert!(is_valid_tln(child, config), ENotSupportedTLN);
-    assert!(is_valid_label(child, config), EInvalidLabelSize);
     assert!(has_valid_depth(child, config), EDepthExceedsLimit);
 }
 

--- a/packages/subnames/sources/subnames.move
+++ b/packages/subnames/sources/subnames.move
@@ -54,6 +54,9 @@ const ESubnameReplaced: vector<u8> =
 #[error]
 const EParentChanged: vector<u8> =
     b"Parent for a given subname has changed, hence time extension cannot be done.";
+#[error]
+const ESubnameParentMismatch: vector<u8> =
+    b"Subname provided is not a valid child of the parent name registration.";
 
 /// Enabled metadata value.
 const ACTIVE_METADATA_VALUE: vector<u8> = b"1";
@@ -76,6 +79,7 @@ public fun new_leaf(
     ctx: &mut TxContext,
 ) {
     let subname = name::new(subname);
+    assert!(parent.name().is_parent_of(&subname), ESubnameParentMismatch);
     validation::assert_not_blocked_or_reserved(iota_names, &subname);
     
     // all validation logic for subname creation / management.
@@ -138,6 +142,7 @@ public fun new(
     ctx: &mut TxContext,
 ): SubnameRegistration {
     let subname = name::new(subname);
+    assert!(parent.name().is_parent_of(&subname), ESubnameParentMismatch);
     validation::assert_not_blocked_or_reserved(iota_names, &subname);
     
     // All validation logic for subname creation / management.

--- a/packages/subnames/sources/subnames.move
+++ b/packages/subnames/sources/subnames.move
@@ -54,9 +54,6 @@ const ESubnameReplaced: vector<u8> =
 #[error]
 const EParentChanged: vector<u8> =
     b"Parent for a given subname has changed, hence time extension cannot be done.";
-#[error]
-const ESubnameParentMismatch: vector<u8> =
-    b"Subname provided is not a valid child of the parent name registration.";
 
 /// Enabled metadata value.
 const ACTIVE_METADATA_VALUE: vector<u8> = b"1";
@@ -79,7 +76,6 @@ public fun new_leaf(
     ctx: &mut TxContext,
 ) {
     let subname = name::new(subname);
-    assert!(parent.name().is_parent_of(&subname), ESubnameParentMismatch);
     validation::assert_not_blocked_or_reserved(iota_names, &subname);
     
     // all validation logic for subname creation / management.
@@ -142,7 +138,6 @@ public fun new(
     ctx: &mut TxContext,
 ): SubnameRegistration {
     let subname = name::new(subname);
-    assert!(parent.name().is_parent_of(&subname), ESubnameParentMismatch);
     validation::assert_not_blocked_or_reserved(iota_names, &subname);
     
     // All validation logic for subname creation / management.

--- a/packages/subnames/tests/unit_tests.move
+++ b/packages/subnames/tests/unit_tests.move
@@ -46,7 +46,7 @@ fun test_parent_relationships() {
 #[test, expected_failure(abort_code = iota_names_subnames::config::EDepthExceedsLimit)]
 fun test_too_large_subname_failure() {
     assert_is_valid_subname(
-        &new_name(utf8(b"example.iota")),
+        &new_name(utf8(b"sub.sub.sub.sub.sub.sub.sub.sub.example.iota")),
         &new_name(
             utf8(
                 b"sub.sub.sub.sub.sub.sub.sub.sub.sub.example.iota",


### PR DESCRIPTION
## Description

Improves the error message for when a new subname is created but does not match the parent, i.e. passing `test.subname.iota` with parent `sub.iota`.

Closes #778