### PR TITLE
feat(ci): remove unnecessary build step

### DIFF
--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -192,10 +192,6 @@ jobs:
           pnpm install
         working-directory: ./
 
-      - name: Build Dapp
-        run: pnpm dapp build
-        working-directory: ./
-
       - name: Download IOTA Wallet Extension
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removes the step where the dapp is built because:
1. It's already being done in the `Prepare local network & Run Dapp e2e tests` line 249
2. When injecting the envs to the sdk for localnet testing, we need to build the sdk again, so we are building twice. The second time we build the dapp uses turbo so it will build the sdk anyways