### PR TITLE
chore(dapp): Revert #712

### DIFF
--- a/dapp/src/lib/utils/defaultRpcClient.ts
+++ b/dapp/src/lib/utils/defaultRpcClient.ts
@@ -26,6 +26,7 @@ export const createIotaClient = (network: NetworkId): IotaClient => {
                 'multiGetObjects',
                 'getReferenceGasPrice',
                 'getNormalizedMoveFunction',
+                'getOwnedObjects',
                 'dryRunTransactionBlock',
                 'executeTransactionBlock',
             ],


### PR DESCRIPTION
Revert #712

we are going back to json rpc for `getOwnedObjects` because seems like the graphql version just doesnt support filters properly

more info: https://github.com/iotaledger/iota/issues/9418