### PR TITLE
chore(e2e): Bump node epoch duration to 15min for e2e tests

### DIFF
--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -205,7 +205,7 @@ jobs:
       - name: Prepare local network & Run Dapp e2e tests
         working-directory: ./
         run: |
-          iota start --with-faucet --faucet-amount 100000000000000 --with-indexer --with-graphql --force-regenesis --epoch-duration-ms 120000 > /dev/null 2>&1 &
+          iota start --with-faucet --faucet-amount 100000000000000 --with-indexer --with-graphql --force-regenesis --epoch-duration-ms 900000 > /dev/null 2>&1 &
           sleep 10
 
           iota client --yes new-env --alias localnet --rpc http://127.0.0.1:9000 --graphql http://127.0.0.1:9125


### PR DESCRIPTION
Related to https://github.com/iotaledger/iota-names/issues/984