### PR TITLE
chore(indexer): temporarily allow RUSTSEC-2025-0134

### DIFF
--- a/indexer/deny.toml
+++ b/indexer/deny.toml
@@ -86,6 +86,8 @@ ignore = [
   # Marvin Attack: potential key recovery through timing sidechannels
   # https://github.com/iotaledger/iota-names/issues/265
   "RUSTSEC-2023-0071",
+  # rustls-pemfile is unmaintained
+  "RUSTSEC-2025-0134",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
rustls-pemfile is unmaintained, waiting for a release of https://github.com/apache/arrow-rs-object-store/pull/565