### PR TITLE
fix(indexer): fix event detection with different packages

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,8 @@ extend-ignore-identifiers-re = [
   "^[a-zA-Z0-9_]{47}$",
   "^[a-zA-Z0-9_]{49}$",
   "^[a-zA-Z0-9_]{56,}$",
+  # Allow "packageid"
+  "^packageid$",
 ]
 
 [files]

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,7 +9,6 @@ extend-ignore-identifiers-re = [
   "^[a-zA-Z0-9_]{47}$",
   "^[a-zA-Z0-9_]{49}$",
   "^[a-zA-Z0-9_]{56,}$",
-  # Allow "packageid"
   "^packageid$",
 ]
 

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -12,7 +12,9 @@ Run the following commands also from the root directory.
 ### Set the environment variables
 
 ```bash
-cd scripts && pnpm ts-node utils/envs.ts localnet > ../indexer/docker/.env && cd ..
+cd scripts && pnpm run envsForIndexer localnet file && cd ..
+# testnet
+cd scripts && pnpm run envsForIndexer testnet file && cd ..
 ```
 
 ### Build the indexer image

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -12,9 +12,9 @@ Run the following commands also from the root directory.
 ### Set the environment variables
 
 ```bash
-cd scripts && pnpm run envsForIndexer localnet file && cd ..
+cd scripts && pnpm run envsForIndexer localnet ../indexer/docker/.env && cd ..
 # testnet
-cd scripts && pnpm run envsForIndexer testnet file && cd ..
+cd scripts && pnpm run envsForIndexer testnet ../indexer/docker/.env && cd ..
 ```
 
 ### Build the indexer image

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -12,6 +12,7 @@ Run the following commands also from the root directory.
 ### Set the environment variables
 
 ```bash
+# localnet
 cd scripts && pnpm run envsForIndexer localnet ../indexer/docker/.env && cd ..
 # testnet
 cd scripts && pnpm run envsForIndexer testnet ../indexer/docker/.env && cd ..

--- a/indexer/docker/docker-compose.yml
+++ b/indexer/docker/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   iota-names-indexer:
     container_name: iota-names-indexer
-    depends_on:
-      prometheus:
-        condition: service_started
     build:
       context: ..
       dockerfile: docker/Dockerfile
@@ -40,6 +37,7 @@ services:
       - IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS=${IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS}
       - IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS=${IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS}
       - IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID=${IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID}
+      - EVENT_PACKAGE_IDS=${EVENT_PACKAGE_IDS}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command:

--- a/indexer/docker/update_progress.sh
+++ b/indexer/docker/update_progress.sh
@@ -28,8 +28,6 @@ echo "Copying updated file to volume..."
 sudo cp /tmp/progress_store /var/lib/docker/volumes/docker_indexer_progress/_data/progress_store
 
 echo "Restarting the container..."
-# docker-compose up -d
-# echo "Done. Indexer is running with progress set to $NEW_VALUE."
 
 docker-compose up
 

--- a/indexer/docker/update_progress.sh
+++ b/indexer/docker/update_progress.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script updates the progress_store file for the iota-names-indexer.
+# It can be used for testing by skipping syncing large parts of the history
+# and testing only from specific checkpoints, allowing faster test runs.
+
+# Testnet checkpoints for reference:
+# Name bought with package id v2 161879819 https://explorer.iota.org/txblock/HkK2osCd8Wj8jh7dsTBB1xTVZmHJbFm7Y27XTuGncws8?network=testnet
+# ./indexer/docker/update_progress.sh 161879819 
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <new_progress_value>"
+  exit 1
+fi
+
+NEW_VALUE=$1
+
+cd "$(dirname "$0")"
+
+echo "Stopping the iota-names-indexer container..."
+docker-compose down
+
+echo "Updating progress_store to $NEW_VALUE..."
+sudo rm -f /tmp/progress_store
+sudo sh -c "echo '{\"iota_names_reader\": $NEW_VALUE}' > /tmp/progress_store"
+
+echo "Copying updated file to volume..."
+sudo cp /tmp/progress_store /var/lib/docker/volumes/docker_indexer_progress/_data/progress_store
+
+echo "Restarting the container..."
+# docker-compose up -d
+# echo "Done. Indexer is running with progress set to $NEW_VALUE."
+
+docker-compose up
+

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 
 use iota_names::config::IotaNamesConfig;
 use iota_protocol_config::Chain;
@@ -59,10 +58,9 @@ impl IotaNamesExtendedConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let iota_names_config = IotaNamesConfig::from_env()?;
 
-        let event_package_ids: Vec<IotaAddress> = serde_json::from_str(
+        let event_package_ids: HashSet<IotaAddress> = serde_json::from_str(
             &std::env::var("EVENT_PACKAGE_IDS").unwrap_or_else(|_| "[]".to_string()),
         )?;
-        let event_package_ids: HashSet<IotaAddress> = event_package_ids.into_iter().collect();
 
         Ok(Self::new(
             std::env::var("IOTA_NAMES_AUCTION_PACKAGE_ADDRESS")?.parse()?,

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::str::FromStr;
 
 use iota_names::config::IotaNamesConfig;
@@ -23,7 +24,7 @@ pub struct IotaNamesExtendedConfig {
     pub auction_house_id: ObjectID,
     /// List of package addresses for events. Not strictly defined to support
     /// new versions
-    pub event_package_ids: Vec<IotaAddress>,
+    pub event_package_ids: HashSet<IotaAddress>,
     pub iota_names_config: IotaNamesConfig,
 }
 
@@ -41,7 +42,7 @@ impl IotaNamesExtendedConfig {
         subnames_package_address: IotaAddress,
         subname_proxy_package_address: IotaAddress,
         auction_house_id: ObjectID,
-        event_package_ids: Vec<IotaAddress>,
+        event_package_ids: HashSet<IotaAddress>,
         iota_names_config: IotaNamesConfig,
     ) -> Self {
         Self {
@@ -61,6 +62,7 @@ impl IotaNamesExtendedConfig {
         let event_package_ids: Vec<IotaAddress> = serde_json::from_str(
             &std::env::var("EVENT_PACKAGE_IDS").unwrap_or_else(|_| "[]".to_string()),
         )?;
+        let event_package_ids: HashSet<IotaAddress> = event_package_ids.into_iter().collect();
 
         Ok(Self::new(
             std::env::var("IOTA_NAMES_AUCTION_PACKAGE_ADDRESS")?.parse()?,
@@ -104,14 +106,23 @@ impl IotaNamesExtendedConfig {
             IotaAddress::from_str(TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS).unwrap();
         let auction_house_id = ObjectID::from_str(AUCTION_HOUSE_ID).unwrap();
 
+        let iota_names_config = IotaNamesConfig::testnet();
+        let mut event_package_ids = HashSet::new();
+        event_package_ids.insert(auction_package_address);
+        event_package_ids.insert(coupons_package_address);
+        event_package_ids.insert(subnames_package_address);
+        event_package_ids.insert(subname_proxy_package_address);
+        event_package_ids.insert(iota_names_config.package_address);
+        event_package_ids.insert(iota_names_config.payments_package_address);
+
         Self::new(
             auction_package_address,
             coupons_package_address,
             subnames_package_address,
             subname_proxy_package_address,
             auction_house_id,
-            vec![],
-            IotaNamesConfig::testnet(),
+            event_package_ids,
+            iota_names_config,
         )
     }
 
@@ -135,14 +146,23 @@ impl IotaNamesExtendedConfig {
             IotaAddress::from_str(TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS).unwrap();
         let auction_house_id = ObjectID::from_str(AUCTION_HOUSE_ID).unwrap();
 
+        let iota_names_config = IotaNamesConfig::devnet();
+        let mut event_package_ids = HashSet::new();
+        event_package_ids.insert(auction_package_address);
+        event_package_ids.insert(coupons_package_address);
+        event_package_ids.insert(subnames_package_address);
+        event_package_ids.insert(subname_proxy_package_address);
+        event_package_ids.insert(iota_names_config.package_address);
+        event_package_ids.insert(iota_names_config.payments_package_address);
+
         Self::new(
             auction_package_address,
             coupons_package_address,
             subnames_package_address,
             subname_proxy_package_address,
             auction_house_id,
-            vec![],
-            IotaNamesConfig::devnet(),
+            event_package_ids,
+            iota_names_config,
         )
     }
 
@@ -150,12 +170,6 @@ impl IotaNamesExtendedConfig {
     pub fn is_iota_names_package(&self, package_address: impl Into<IotaAddress>) -> bool {
         let package_address = package_address.into();
 
-        package_address == self.auction_package_address
-            || package_address == self.coupons_package_address
-            || package_address == self.iota_names_config.package_address
-            || package_address == self.iota_names_config.payments_package_address
-            || package_address == self.subnames_package_address
-            || package_address == self.subname_proxy_package_address
-            || self.event_package_ids.contains(&package_address)
+        self.event_package_ids.contains(&package_address)
     }
 }

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -7,7 +7,6 @@ use iota_names::config::IotaNamesConfig;
 use iota_protocol_config::Chain;
 use iota_types::base_types::{IotaAddress, ObjectID};
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -22,7 +22,7 @@ pub struct IotaNamesExtendedConfig {
     /// ID of the `AuctionHouse` object.
     pub auction_house_id: ObjectID,
     /// List of package addresses for events. Not strictly defined to support
-    /// new versions
+    /// new versions.
     pub event_package_ids: HashSet<IotaAddress>,
     pub iota_names_config: IotaNamesConfig,
 }

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -105,13 +105,14 @@ impl IotaNamesExtendedConfig {
         let auction_house_id = ObjectID::from_str(AUCTION_HOUSE_ID).unwrap();
 
         let iota_names_config = IotaNamesConfig::testnet();
-        let mut event_package_ids = HashSet::new();
-        event_package_ids.insert(auction_package_address);
-        event_package_ids.insert(coupons_package_address);
-        event_package_ids.insert(subnames_package_address);
-        event_package_ids.insert(subname_proxy_package_address);
-        event_package_ids.insert(iota_names_config.package_address);
-        event_package_ids.insert(iota_names_config.payments_package_address);
+        let event_package_ids = HashSet::from([
+            auction_package_address,
+            coupons_package_address,
+            subnames_package_address,
+            subname_proxy_package_address,
+            iota_names_config.package_address,
+            iota_names_config.payments_package_address,
+        ]);
 
         Self::new(
             auction_package_address,
@@ -145,13 +146,14 @@ impl IotaNamesExtendedConfig {
         let auction_house_id = ObjectID::from_str(AUCTION_HOUSE_ID).unwrap();
 
         let iota_names_config = IotaNamesConfig::devnet();
-        let mut event_package_ids = HashSet::new();
-        event_package_ids.insert(auction_package_address);
-        event_package_ids.insert(coupons_package_address);
-        event_package_ids.insert(subnames_package_address);
-        event_package_ids.insert(subname_proxy_package_address);
-        event_package_ids.insert(iota_names_config.package_address);
-        event_package_ids.insert(iota_names_config.payments_package_address);
+        let event_package_ids = HashSet::from([
+            auction_package_address,
+            coupons_package_address,
+            subnames_package_address,
+            subname_proxy_package_address,
+            iota_names_config.package_address,
+            iota_names_config.payments_package_address,
+        ]);
 
         Self::new(
             auction_package_address,

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -7,6 +7,7 @@ use iota_names::config::IotaNamesConfig;
 use iota_protocol_config::Chain;
 use iota_types::base_types::{IotaAddress, ObjectID};
 use serde::{Deserialize, Serialize};
+use serde_json;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -21,6 +22,9 @@ pub struct IotaNamesExtendedConfig {
     pub subname_proxy_package_address: IotaAddress,
     /// ID of the `AuctionHouse` object.
     pub auction_house_id: ObjectID,
+    /// List of package addresses for events. Not strictly defined to support
+    /// new versions
+    pub event_package_ids: Vec<IotaAddress>,
     pub iota_names_config: IotaNamesConfig,
 }
 
@@ -38,6 +42,7 @@ impl IotaNamesExtendedConfig {
         subnames_package_address: IotaAddress,
         subname_proxy_package_address: IotaAddress,
         auction_house_id: ObjectID,
+        event_package_ids: Vec<IotaAddress>,
         iota_names_config: IotaNamesConfig,
     ) -> Self {
         Self {
@@ -46,6 +51,7 @@ impl IotaNamesExtendedConfig {
             subnames_package_address,
             subname_proxy_package_address,
             auction_house_id,
+            event_package_ids,
             iota_names_config,
         }
     }
@@ -53,12 +59,17 @@ impl IotaNamesExtendedConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let iota_names_config = IotaNamesConfig::from_env()?;
 
+        let event_package_ids: Vec<IotaAddress> = serde_json::from_str(
+            &std::env::var("EVENT_PACKAGE_IDS").unwrap_or_else(|_| "[]".to_string()),
+        )?;
+
         Ok(Self::new(
             std::env::var("IOTA_NAMES_AUCTION_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_COUPONS_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS")?.parse()?,
             std::env::var("IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID")?.parse()?,
+            event_package_ids,
             iota_names_config,
         ))
     }
@@ -100,6 +111,7 @@ impl IotaNamesExtendedConfig {
             subnames_package_address,
             subname_proxy_package_address,
             auction_house_id,
+            vec![],
             IotaNamesConfig::testnet(),
         )
     }
@@ -130,6 +142,7 @@ impl IotaNamesExtendedConfig {
             subnames_package_address,
             subname_proxy_package_address,
             auction_house_id,
+            vec![],
             IotaNamesConfig::devnet(),
         )
     }
@@ -144,5 +157,6 @@ impl IotaNamesExtendedConfig {
             || package_address == self.iota_names_config.payments_package_address
             || package_address == self.subnames_package_address
             || package_address == self.subname_proxy_package_address
+            || self.event_package_ids.contains(&package_address)
     }
 }

--- a/indexer/src/events.rs
+++ b/indexer/src/events.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::IotaNamesExtendedConfig;
 
+#[derive(Debug)]
 pub(crate) enum IotaNamesEvent {
     // `auctions`
     AuctionStarted(AuctionStartedEvent),
@@ -36,7 +37,7 @@ impl IotaNamesEvent {
         event: &Event,
         config: &IotaNamesExtendedConfig,
     ) -> anyhow::Result<Option<Self>> {
-        if !config.is_iota_names_package(event.package_id) {
+        if !config.is_iota_names_package(event.type_.address) {
             return Ok(None);
         }
 
@@ -77,7 +78,7 @@ impl IotaNamesEvent {
 
 // `auctions`
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AuctionStartedEvent {
     pub name: Name,
     pub start_timestamp_ms: u64,
@@ -86,20 +87,20 @@ pub(crate) struct AuctionStartedEvent {
     pub bidder: IotaAddress,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AuctionBidEvent {
     pub name: Name,
     pub bid: u64,
     pub bidder: IotaAddress,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AuctionExtendedEvent {
     pub name: Name,
     pub end_timestamp_ms: u64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AuctionFinalizedEvent {
     pub name: Name,
     pub start_timestamp_ms: u64,
@@ -110,14 +111,14 @@ pub(crate) struct AuctionFinalizedEvent {
 
 // `coupons`
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum CouponKind {
     Percentage = 0,
     Fixed = 1,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CouponAppliedEvent {
     pub kind: CouponKind,
     pub discount: u64,
@@ -125,48 +126,48 @@ pub struct CouponAppliedEvent {
 
 // `iota-names`
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct NameRecordAddedEvent {
     pub name: Name,
     pub name_record: NameRecord,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct NameRecordRemovedEvent {
     pub name: Name,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TargetAddressSetEvent {
     pub name: Name,
     pub target_address: Option<IotaAddress>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ReverseLookupSetEvent {
     pub default_address: IotaAddress,
     pub default_name: Name,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ReverseLookupUnsetEvent {
     pub default_address: IotaAddress,
     pub default_name: Name,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct UserDataSetEvent {
     pub key: String,
     pub value: String,
     pub new: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct UserDataUnsetEvent {
     pub key: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TransactionEvent {
     pub app: String,
     pub name: Name,
@@ -181,7 +182,7 @@ pub(crate) struct TransactionEvent {
 
 // `subnames`
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NodeSubnameCreatedEvent {
     pub name: Name,
     pub expiration_timestamp_ms: u64,
@@ -189,18 +190,18 @@ pub struct NodeSubnameCreatedEvent {
     pub allow_time_extension: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NodeSubnameBurnedEvent {
     pub name: Name,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LeafSubnameCreatedEvent {
     pub name: Name,
     pub target: IotaAddress,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LeafSubnameRemovedEvent {
     pub name: Name,
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -143,6 +143,9 @@ impl Command {
                         IotaNamesExtendedConfig::from_chain(&chain)
                     }
                 };
+                if iota_names_config.event_package_ids.is_empty() {
+                    panic!("No EVENT_PACKAGE_IDS provided in the environment variables");
+                }
                 info!("Starting with IOTA-Names config: {iota_names_config:#?}");
                 tasks.spawn(async move {
                     let worker = IotaNamesWorker::new(

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -32,7 +32,7 @@ use move_core_types::{
 };
 use prometheus::Registry;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     IotaNamesMetrics,
@@ -141,6 +141,7 @@ impl IotaNamesWorker {
     }
 
     fn process_event(&self, event: IotaNamesEvent) -> anyhow::Result<()> {
+        debug!("Processing event: {event:?}");
         match event {
             // `auctions`
             IotaNamesEvent::AuctionStarted(event) => {
@@ -277,10 +278,16 @@ impl IotaNamesWorker {
     }
 
     async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
-        debug!(
+        trace!(
             "Processing checkpoint: {}",
             checkpoint.checkpoint_summary.sequence_number
         );
+        if checkpoint.checkpoint_summary.sequence_number % 10_000 == 0 {
+            debug!(
+                "Processing checkpoint: {}",
+                checkpoint.checkpoint_summary.sequence_number
+            );
+        }
 
         let mut iota_names_balance = false;
         let mut auction_house_balance = false;
@@ -311,7 +318,13 @@ impl IotaNamesWorker {
             if let Some(events) = &transaction.events {
                 for event in events.data.iter() {
                     match IotaNamesEvent::try_from_event(event, &self.extended_config) {
-                        Ok(Some(event)) => self.process_event(event)?,
+                        Ok(Some(event)) => {
+                            debug!(
+                                "Event in checkpoint: {}",
+                                checkpoint.checkpoint_summary.sequence_number
+                            );
+                            self.process_event(event)?
+                        }
                         Err(e) => warn!("parsing event failed: {e}"),
                         _ => {}
                     }

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -311,8 +311,6 @@ impl IotaNamesWorker {
             }
         }
 
-        let mut event_checkpoint_logged = false;
-
         for transaction in &checkpoint.transactions {
             let TransactionEffects::V1(effects) = &transaction.effects;
 
@@ -324,14 +322,11 @@ impl IotaNamesWorker {
                 for event in events.data.iter() {
                     match IotaNamesEvent::try_from_event(event, &self.extended_config) {
                         Ok(Some(event)) => {
-                            if !event_checkpoint_logged {
-                                debug!(
-                                    "Event in checkpoint: {}",
-                                    checkpoint.checkpoint_summary.sequence_number
-                                );
-                                event_checkpoint_logged = true;
-                            }
-                            debug!("Processing event: {event:?}");
+                            debug!(
+                                "Processing event in checkpoint {}: {event:?}",
+                                checkpoint.checkpoint_summary.sequence_number
+                            );
+
                             self.process_event(event)?
                         }
                         Err(e) => warn!("parsing event failed: {e}"),

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -282,7 +282,11 @@ impl IotaNamesWorker {
             "Processing checkpoint: {}",
             checkpoint.checkpoint_summary.sequence_number
         );
-        if checkpoint.checkpoint_summary.sequence_number % 10_000 == 0 {
+        if checkpoint
+            .checkpoint_summary
+            .sequence_number
+            .is_multiple_of(10_000)
+        {
             debug!(
                 "Processing checkpoint: {}",
                 checkpoint.checkpoint_summary.sequence_number

--- a/indexer/src/worker.rs
+++ b/indexer/src/worker.rs
@@ -141,7 +141,6 @@ impl IotaNamesWorker {
     }
 
     fn process_event(&self, event: IotaNamesEvent) -> anyhow::Result<()> {
-        debug!("Processing event: {event:?}");
         match event {
             // `auctions`
             IotaNamesEvent::AuctionStarted(event) => {
@@ -312,6 +311,8 @@ impl IotaNamesWorker {
             }
         }
 
+        let mut event_checkpoint_logged = false;
+
         for transaction in &checkpoint.transactions {
             let TransactionEffects::V1(effects) = &transaction.effects;
 
@@ -323,10 +324,14 @@ impl IotaNamesWorker {
                 for event in events.data.iter() {
                     match IotaNamesEvent::try_from_event(event, &self.extended_config) {
                         Ok(Some(event)) => {
-                            debug!(
-                                "Event in checkpoint: {}",
-                                checkpoint.checkpoint_summary.sequence_number
-                            );
+                            if !event_checkpoint_logged {
+                                debug!(
+                                    "Event in checkpoint: {}",
+                                    checkpoint.checkpoint_summary.sequence_number
+                                );
+                                event_checkpoint_logged = true;
+                            }
+                            debug!("Processing event: {event:?}");
                             self.process_event(event)?
                         }
                         Err(e) => warn!("parsing event failed: {e}"),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,7 +17,8 @@
         "eslint:fix": "pnpm run eslint:check --fix",
         "lint": "pnpm run eslint:check && pnpm run prettier:check",
         "lint:fix": "pnpm run eslint:fix && pnpm run prettier:fix",
-        "envs": "ts-node utils/envs.ts"
+        "envs": "ts-node utils/envs.ts",
+        "envsForIndexer": "ts-node utils/envsForIndexer.ts"
     },
     "keywords": [],
     "author": "",

--- a/scripts/utils/envsForIndexer.ts
+++ b/scripts/utils/envsForIndexer.ts
@@ -90,5 +90,5 @@ outputLines.push(formatEnvVar('EVENT_PACKAGE_IDS', JSON.stringify(eventPackageId
 if (file) {
     fs.writeFileSync(file, outputLines.join('\n') + '\n');
 } else {
-    outputLines.forEach(line => console.log(line));
+    outputLines.forEach((line) => console.log(line));
 }

--- a/scripts/utils/envsForIndexer.ts
+++ b/scripts/utils/envsForIndexer.ts
@@ -3,40 +3,14 @@
 
 // Get environment variables from a config to set for the iota-names-indexer.
 // Also collects all package IDs (hex strings starting with 0x and 66 chars long) into EVENT_PACKAGE_IDS.
-// pnpm run envsForIndexer <network> [shell] [file]
+// Usage: pnpm run envsForIndexer <network> [file] [shell]
 
 import * as fs from 'fs';
 
-const [, , network, shell = 'bash'] = process.argv;
-
-if (!network) {
-    console.error('Usage: pnpm run utils/envs.ts <network> [shell]');
-    process.exit(1);
-}
-
-const filePath = `package-info/${network}.json`;
-
-if (!fs.existsSync(filePath)) {
-    console.error(`Error: JSON config file not found at ${filePath}`);
-    process.exit(1);
-}
-
-const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-
-const envVars = {
-    IOTA_NAMES_PACKAGE_ADDRESS: json.packageId.v1,
-    IOTA_NAMES_OBJECT_ID: json.iotaNamesObjectId,
-    IOTA_NAMES_PAYMENTS_PACKAGE_ADDRESS: json.paymentsPackageId.v1,
-    IOTA_NAMES_REGISTRY_ID: json.registryTableId,
-    IOTA_NAMES_REVERSE_REGISTRY_ID: json.reverseRegistryTableId,
-    IOTA_NAMES_AUCTION_PACKAGE_ADDRESS: json.auctionPackageId.v1,
-    IOTA_NAMES_COUPONS_PACKAGE_ADDRESS: json.couponsPackageId.v1,
-    IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS: json.subnamesPackageId.v1,
-    IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS: json.tempSubnameProxyPackageId.v1,
-    IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID: json.auctionHouseObjectId,
-};
-
-function formatEnvVar(name: string, value: string): string {
+/**
+ * Formats an environment variable for the specified shell.
+ */
+function formatEnvVar(name: string, value: string, shell: string): string {
     if (shell === 'fish') {
         return `set -x ${name} ${value};`;
     }
@@ -44,29 +18,77 @@ function formatEnvVar(name: string, value: string): string {
     return `export ${name}=${value}`;
 }
 
-const output: string[] = [];
-
-Object.entries(envVars).forEach(([key, value]) => {
-    output.push(formatEnvVar(key, value));
-});
-
-function collectHexStrings(obj: any, arr: string[]): void {
-    if (typeof obj === 'string' && /^0x[a-f0-9]{64}$/.test(obj)) {
+/**
+ * Recursively collects package IDs (hex strings of 66 characters starting with 0x) from the config object.
+ */
+function collectPackageIds(obj: any, arr: string[], isPackageId: boolean = false): void {
+    if (typeof obj === 'string' && isPackageId && /^0x[a-f0-9]{64}$/.test(obj)) {
         arr.push(obj);
     } else if (typeof obj === 'object' && obj !== null) {
-        for (const value of Object.values(obj)) {
-            collectHexStrings(value, arr);
+        for (const [key, value] of Object.entries(obj)) {
+            const newIsPackageId = isPackageId || key.toLowerCase().includes('packageid');
+            collectPackageIds(value, arr, newIsPackageId);
         }
     }
 }
 
+// Parse command line arguments
+const [, , network, arg3, arg4] = process.argv;
+
+let file: string | undefined;
+let shell = 'bash';
+
+if (arg3) {
+    if (arg3 === 'bash' || arg3 === 'fish') {
+        shell = arg3;
+        file = arg4;
+    } else {
+        file = arg3;
+        if (arg4 === 'bash' || arg4 === 'fish') {
+            shell = arg4;
+        }
+    }
+}
+
+if (!network) {
+    console.error('Usage: pnpm run envsForIndexer <network> [file] [shell]');
+    process.exit(1);
+}
+
+// Load and parse the config file
+const configFilePath = `package-info/${network}.json`;
+if (!fs.existsSync(configFilePath)) {
+    console.error(`Error: JSON config file not found at ${configFilePath}`);
+    process.exit(1);
+}
+
+const config = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'));
+
+// Define environment variables mapping
+const envVars: Record<string, string> = {
+    IOTA_NAMES_PACKAGE_ADDRESS: config.packageId.v1,
+    IOTA_NAMES_OBJECT_ID: config.iotaNamesObjectId,
+    IOTA_NAMES_PAYMENTS_PACKAGE_ADDRESS: config.paymentsPackageId.v1,
+    IOTA_NAMES_REGISTRY_ID: config.registryTableId,
+    IOTA_NAMES_REVERSE_REGISTRY_ID: config.reverseRegistryTableId,
+    IOTA_NAMES_AUCTION_PACKAGE_ADDRESS: config.auctionPackageId.v1,
+    IOTA_NAMES_COUPONS_PACKAGE_ADDRESS: config.couponsPackageId.v1,
+    IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS: config.subnamesPackageId.v1,
+    IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS: config.tempSubnameProxyPackageId.v1,
+    IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID: config.auctionHouseObjectId,
+};
+
+// Collect package IDs for events
 const eventPackageIds: string[] = [];
-collectHexStrings(json, eventPackageIds);
+collectPackageIds(config, eventPackageIds);
 
-output.push(formatEnvVar('EVENT_PACKAGE_IDS', JSON.stringify(eventPackageIds)));
+// Generate output lines
+const outputLines = Object.entries(envVars).map(([key, value]) => formatEnvVar(key, value, shell));
+outputLines.push(formatEnvVar('EVENT_PACKAGE_IDS', JSON.stringify(eventPackageIds), shell));
 
-if (process.argv[3] === 'file') {
-    fs.writeFileSync('../indexer/docker/.env', output.join('\n') + '\n');
+// Output to file or console
+if (file) {
+    fs.writeFileSync(file, outputLines.join('\n') + '\n');
 } else {
-    output.forEach(line => console.log(line));
+    outputLines.forEach(line => console.log(line));
 }

--- a/scripts/utils/envsForIndexer.ts
+++ b/scripts/utils/envsForIndexer.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// Get environment variables from a config to set for the iota-names-indexer.
+// Also collects all package IDs (hex strings starting with 0x and 66 chars long) into EVENT_PACKAGE_IDS.
+// pnpm run envsForIndexer <network> [shell] [file]
+
+import * as fs from 'fs';
+
+const [, , network, shell = 'bash'] = process.argv;
+
+if (!network) {
+    console.error('Usage: pnpm run utils/envs.ts <network> [shell]');
+    process.exit(1);
+}
+
+const filePath = `package-info/${network}.json`;
+
+if (!fs.existsSync(filePath)) {
+    console.error(`Error: JSON config file not found at ${filePath}`);
+    process.exit(1);
+}
+
+const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+const envVars = {
+    IOTA_NAMES_PACKAGE_ADDRESS: json.packageId.v1,
+    IOTA_NAMES_OBJECT_ID: json.iotaNamesObjectId,
+    IOTA_NAMES_PAYMENTS_PACKAGE_ADDRESS: json.paymentsPackageId.v1,
+    IOTA_NAMES_REGISTRY_ID: json.registryTableId,
+    IOTA_NAMES_REVERSE_REGISTRY_ID: json.reverseRegistryTableId,
+    IOTA_NAMES_AUCTION_PACKAGE_ADDRESS: json.auctionPackageId.v1,
+    IOTA_NAMES_COUPONS_PACKAGE_ADDRESS: json.couponsPackageId.v1,
+    IOTA_NAMES_SUBNAMES_PACKAGE_ADDRESS: json.subnamesPackageId.v1,
+    IOTA_NAMES_TEMP_SUBNAME_PROXY_PACKAGE_ADDRESS: json.tempSubnameProxyPackageId.v1,
+    IOTA_NAMES_AUCTION_HOUSE_OBJECT_ID: json.auctionHouseObjectId,
+};
+
+function formatEnvVar(name: string, value: string): string {
+    if (shell === 'fish') {
+        return `set -x ${name} ${value};`;
+    }
+    // Default to bash/zsh
+    return `export ${name}=${value}`;
+}
+
+const output: string[] = [];
+
+Object.entries(envVars).forEach(([key, value]) => {
+    output.push(formatEnvVar(key, value));
+});
+
+function collectHexStrings(obj: any, arr: string[]): void {
+    if (typeof obj === 'string' && /^0x[a-f0-9]{64}$/.test(obj)) {
+        arr.push(obj);
+    } else if (typeof obj === 'object' && obj !== null) {
+        for (const value of Object.values(obj)) {
+            collectHexStrings(value, arr);
+        }
+    }
+}
+
+const eventPackageIds: string[] = [];
+collectHexStrings(json, eventPackageIds);
+
+output.push(formatEnvVar('EVENT_PACKAGE_IDS', JSON.stringify(eventPackageIds)));
+
+if (process.argv[3] === 'file') {
+    fs.writeFileSync('../indexer/docker/.env', output.join('\n') + '\n');
+} else {
+    output.forEach(line => console.log(line));
+}


### PR DESCRIPTION
After the package v2 the package version didn't match what we compared against from the events anymore. To work around that, now we compare the event type package id (the package id in which an event was defined) and also just add all package ids to check against so new updates just require to add a new event and then run the envsForIndexer script to also get this detected.
Also reworked the debug logs to print less checkpoints, but iota names events instead

Tested locally with the testnet and the new indexer/docker/update_progress.sh script to skip syncing to registrations with the v2 package and then looked at the grafana stats and debug logs to verify that now all events are detected

```
cd scripts && pnpm run envsForIndexer testnet ../indexer/docker/.env && cd ..

docker compose -f indexer/docker/docker-compose.yml build --build-arg CACHEBUST=$(date +%s)

docker compose -f indexer/docker/docker-compose.yml down -v

docker compose -f indexer/docker/docker-compose.yml up

# opened http://localhost:3000 and logged in with admin admin
# checked the dashboard with iota-names

# stopped the docker compose with Ctrl+C, then started again with new checkpoint where the v2 package version was used already:
./indexer/docker/update_progress.sh 161879819 

# debug logs show all events are detected:
iota-names-indexer    | 2026-01-08T17:07:56.395021Z DEBUG iota_names_indexer::worker: Event in checkpoint: 161879819
iota-names-indexer    | 2026-01-08T17:07:56.395051Z DEBUG iota_names_indexer::worker: Processing event: Transaction(TransactionEvent { app: "6b1b01f4c72786a893191d5c6e73d3012f7529f86fdee3bc8c163323cee08441::payments::PaymentsAuth", name: Name { labels: ["iota", "web777"] }, years: 1, request_data_version: 1, base_amount: 50000000000, metadata: VecMap { contents: [] }, is_renewal: false, currency: "0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA", currency_amount: 50000000000 })
iota-names-indexer    | 2026-01-08T17:07:56.395080Z DEBUG iota_names_indexer::worker: Event in checkpoint: 161879819
iota-names-indexer    | 2026-01-08T17:07:56.395093Z DEBUG iota_names_indexer::worker: Processing event: NameRecordAdded(NameRecordAddedEvent { name: Name { labels: ["iota", "web777"] }, name_record: NameRecord { nft_id: ID { bytes: 0xf0e7e5dc92791bd7cca48465b8f25765457356d41958964479736985a5addb4b }, expiration_timestamp_ms: 1799333227781, target_address: None, data: VecMap { contents: [] } } })
iota-names-indexer    | 2026-01-08T17:07:56.395118Z DEBUG iota_names_indexer::worker: Event in checkpoint: 161879819
iota-names-indexer    | 2026-01-08T17:07:56.395126Z DEBUG iota_names_indexer::worker: Processing event: TargetAddressSet(TargetAddressSetEvent { name: Name { labels: ["iota", "web777"] }, target_address: Some(0xa8ef2a97154b56734553938ef7203da7533d84ea177607045a1029c327e219ee) })
iota-names-indexer    | 2026-01-08T17:07:56.395142Z DEBUG iota_names_indexer::worker: Event in checkpoint: 161879819
iota-names-indexer    | 2026-01-08T17:07:56.395149Z DEBUG iota_names_indexer::worker: Processing event: ReverseLookupSet(ReverseLookupSetEvent { default_address: 0xa8ef2a97154b56734553938ef7203da7533d84ea177607045a1029c327e219ee, default_name: Name { labels: ["iota", "web777"] } })

# dashboard also shows balance and records increased together
```