### PR TITLE
chore: Ignore RUSTSEC-2025-0141

### DIFF
--- a/indexer/deny.toml
+++ b/indexer/deny.toml
@@ -86,8 +86,12 @@ ignore = [
   # Marvin Attack: potential key recovery through timing sidechannels
   # https://github.com/iotaledger/iota-names/issues/265
   "RUSTSEC-2023-0071",
-  # rustls-pemfile is unmaintained
+  # `rustls-pemfile` is unmaintained
   "RUSTSEC-2025-0134",
+  # `bincode` is unmaintained
+  "RUSTSEC-2025-0141",
+  # `IterMut` violates Stacked Borrows by invalidating internal pointer (FIX ASAP)
+  "RUSTSEC-2026-0002",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/indexer/deny.toml
+++ b/indexer/deny.toml
@@ -90,8 +90,6 @@ ignore = [
   "RUSTSEC-2025-0134",
   # `bincode` is unmaintained
   "RUSTSEC-2025-0141",
-  # `IterMut` violates Stacked Borrows by invalidating internal pointer (FIX ASAP)
-  "RUSTSEC-2026-0002",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
## Description

Ignores a new RUSTSEC issue:

- bincode is unmaintained [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141)