### PR TITLE
chore(docs): temporarily hide user docs until updates are merged

### DIFF
--- a/documentation/pages/_meta.json
+++ b/documentation/pages/_meta.json
@@ -1,7 +1,10 @@
 {
     "index": "IOTA-Names Documentation",
     "developer": "Developer",
-    "user": "User",
+    "user": {
+        "title": "User",
+        "display": "hidden"
+    },
     "dapp": {
         "title": "IOTA-Names Dapp ↗",
         "type": "page",


### PR DESCRIPTION
User docs are not currently up to date with the Dapp interface. We will temporarily disable them until updates are merged to develop