### PR TITLE
feat(indexer): add sorting by ending time

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,8 +9,11 @@ extend-ignore-identifiers-re = [
   "^[a-zA-Z0-9_]{47}$",
   "^[a-zA-Z0-9_]{49}$",
   "^[a-zA-Z0-9_]{56,}$",
-  "^packageid$",
 ]
+
+[default.extend-words]
+packageid = "packageid"
+pont = "pont"
 
 [files]
 extend-exclude = [

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -84,3 +84,48 @@ Returns all names that a specific address has bid on.
 ```bash
 curl http://localhost:3030/auctions/0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215
 ```
+
+### Get Auctions
+
+```
+GET /auctions
+```
+
+Returns a paginated list of all auctions, with optional filtering and sorting.
+
+**Parameters:**
+
+- `page` (optional): Page number (0-based, default: 0)
+- `pageSize` (optional): Number of items per page (default: 50, max: 100)
+- `sort` (optional): Sort order (`asc` or `desc`, default: `asc`)
+- `sortBy` (optional): Sort field (`name`, `bid`, or `ending`, default: `name`)
+- `search` (optional): Search term to filter names
+- `status` (optional): Filter by auction status (`active`, `finished`, or `claimed`)
+
+**Response:**
+
+```json
+{
+  "names": [
+    "thoralf.iota",
+    "branmuffins.iota",
+    "brah.iota",
+    "114514.iota",
+    "pont.iota",
+    "ulim1408.iota",
+    "space.iota",
+    "cards.iota",
+    "iot.iota",
+    "dex.iota"
+  ],
+  "page": 0,
+  "pageSize": 10,
+  "totalItems": 391
+}
+```
+
+**Example with sorting by ending time:**
+
+```bash
+curl http://localhost:3030/auctions?sortBy=ending&sort=asc&pageSize=10
+```

--- a/indexer/src/db/mod.rs
+++ b/indexer/src/db/mod.rs
@@ -31,6 +31,7 @@ pub enum AuctionSortBy {
     #[default]
     Name,
     Bid,
+    Ending,
 }
 
 impl std::str::FromStr for AuctionSortBy {
@@ -40,8 +41,9 @@ impl std::str::FromStr for AuctionSortBy {
         Ok(match s {
             "name" => AuctionSortBy::Name,
             "bid" => AuctionSortBy::Bid,
+            "ending" => AuctionSortBy::Ending,
             _ => Err(anyhow::anyhow!(
-                "Invalid sort by descriptor. Expected `name` or `bid`, found `{s}`"
+                "Invalid sort by descriptor. Expected `name`, `bid`, or `ending`, found `{s}`"
             ))?,
         })
     }

--- a/indexer/src/db/queries.rs
+++ b/indexer/src/db/queries.rs
@@ -206,6 +206,16 @@ pub fn get_auctions(
         (SortOrder::Desc, AuctionSortBy::Bid) => {
             query.order((dsl::max(bids::bid).desc(), names::id.desc()))
         }
+        (SortOrder::Asc, AuctionSortBy::Ending) => query.order((
+            // Put already ended auctions at the end when sorting ascending
+            auctions::expiration_timestamp
+                .gt(now.timestamp_millis())
+                .desc(),
+            auctions::expiration_timestamp.asc(),
+        )),
+        (SortOrder::Desc, AuctionSortBy::Ending) => {
+            query.order(auctions::expiration_timestamp.desc())
+        }
     };
     Ok(query
         .load::<(Name, Option<i64>)>(conn)?


### PR DESCRIPTION
Support sorting auctions by their end time, but when sorting ascending, move the already ended auctions to the end, so in the dApp it will start with the auctions that are just about to end and nto already ended ones

Tested locally by running the indexer with the mainnet config:
```
curl http://localhost:3030/auctions\?sortBy\=ending\&sort\=asc\&pageSize\=10 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   187  100   187    0     0   101k      0 --:--:-- --:--:-- --:--:--  182k
{
  "names": [
    "thoralf.iota",
    "branmuffins.iota",
    "brah.iota",
    "114514.iota",
    "pont.iota",
    "ulim1408.iota",
    "space.iota",
    "cards.iota",
    "iot.iota",
    "dex.iota"
  ],
  "page": 0,
  "pageSize": 10,
  "totalItems": 445
}
```