### PR TITLE
fix(ts-sdk): add retries when fetching balance data

### DIFF
--- a/sdk/test/toolbox.ts
+++ b/sdk/test/toolbox.ts
@@ -71,9 +71,18 @@ export async function setupIotaClient() {
         logger: (msg) => console.warn('Retrying requesting from faucet: ' + msg),
     });
 
-    const b = await client.getBalance({
-        owner: address,
-    });
+    const b = await retry(
+        () =>
+            client.getBalance({
+                owner: address,
+            }),
+        {
+            retries: 10,
+            delay: 1000,
+            logger: (msg) => console.warn('Retrying getting balance: ' + msg),
+            retryIf: (error: any) => error.message.includes('Missing response data'),
+        },
+    );
     console.log(`Balance for ${address}: ${b.totalBalance} IOTA`);
 
     const tmpDirPath = path.join(tmpdir(), 'config-');

--- a/sdk/test/toolbox.ts
+++ b/sdk/test/toolbox.ts
@@ -77,8 +77,8 @@ export async function setupIotaClient() {
                 owner: address,
             }),
         {
-            retries: 10,
-            delay: 1000,
+            retries: 100,
+            delay: 50,
             logger: (msg) => console.warn('Retrying getting balance: ' + msg),
             retryIf: (error: any) => error.message.includes('Missing response data'),
         },


### PR DESCRIPTION
Fixes #1045

Balance is probably not propagated since the faucet is correctly requested, so we need to give some time

A run that would have failed without the fix: https://github.com/iotaledger/iota-names/actions/runs/21175631179/job/61008204575#step:11:303