### PR TITLE
chore(dapp): rename ui filter from owned to names

### DIFF
--- a/dapp/src/app/(protected)/my-names/filters.ts
+++ b/dapp/src/app/(protected)/my-names/filters.ts
@@ -4,6 +4,6 @@
 export enum GroupedNamesFilter {
     All = 'All',
     InAuction = 'In Auction',
-    Owned = 'Owned',
+    Names = 'Names',
     Subnames = 'Subnames',
 }

--- a/dapp/src/app/(protected)/my-names/page.tsx
+++ b/dapp/src/app/(protected)/my-names/page.tsx
@@ -88,7 +88,7 @@ export default function MyNamesPage(): JSX.Element {
                 return [...namesRegistrations, ...subnamesRegistrations, ...auctionCards];
             case GroupedNamesFilter.InAuction:
                 return auctionCards;
-            case GroupedNamesFilter.Owned:
+            case GroupedNamesFilter.Names:
                 return namesRegistrations;
             case GroupedNamesFilter.Subnames:
                 return subnamesRegistrations;
@@ -178,7 +178,7 @@ export default function MyNamesPage(): JSX.Element {
                             onClick={() => handleFilterSelect(value)}
                             disabled={
                                 (value === GroupedNamesFilter.InAuction && noAuctions) ||
-                                (value === GroupedNamesFilter.Owned && !names?.length) ||
+                                (value === GroupedNamesFilter.Names && !names?.length) ||
                                 (value === GroupedNamesFilter.Subnames && !subnames?.length)
                             }
                         />


### PR DESCRIPTION
the "owned" filter is confusing because we are not really filtering all owned objects but rather filter all owned names (not subnames)