### PR TITLE
fix(dapp): Aggressive wait mode for tx polling

### DIFF
--- a/dapp/src/components/dialogs/PurchaseNameDialog.tsx
+++ b/dapp/src/components/dialogs/PurchaseNameDialog.tsx
@@ -148,6 +148,7 @@ export function PurchaseNameDialog({ name, open, setOpen, onCompleted }: Purchas
 
             await client.waitForTransaction({
                 digest: transactionResult.digest,
+                waitMode: 'checkpoint'
             });
         },
         onSuccess() {

--- a/dapp/src/components/dialogs/PurchaseNameDialog.tsx
+++ b/dapp/src/components/dialogs/PurchaseNameDialog.tsx
@@ -148,7 +148,7 @@ export function PurchaseNameDialog({ name, open, setOpen, onCompleted }: Purchas
 
             await client.waitForTransaction({
                 digest: transactionResult.digest,
-                waitMode: 'checkpoint'
+                waitMode: 'checkpoint',
             });
         },
         onSuccess() {


### PR DESCRIPTION
Seems like we were hitting a race condition because of latency between the tx execution and the graphql data fetching.