### PR TITLE
fix(dapp): Download the chrome build of the wallet in the download script

### DIFF
--- a/dapp/scripts/download_wallet_artifact.sh
+++ b/dapp/scripts/download_wallet_artifact.sh
@@ -26,7 +26,7 @@ ARTIFACT_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
 jq -r '.workflow_runs[0].artifacts_url' | \
 xargs curl -s -H "Authorization: token $GITHUB_TOKEN" \
      -H "Accept: application/vnd.github.v3+json" | \
-jq -r '.artifacts[0].id')
+jq -r '.artifacts | min_by(.id) | .id')
 
 if [ -z "$ARTIFACT_ID" ] || [ "$ARTIFACT_ID" = "null" ]; then
     echo "Error: No artifacts found"

--- a/dapp/scripts/download_wallet_artifact.sh
+++ b/dapp/scripts/download_wallet_artifact.sh
@@ -26,7 +26,7 @@ ARTIFACT_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
 jq -r '.workflow_runs[0].artifacts_url' | \
 xargs curl -s -H "Authorization: token $GITHUB_TOKEN" \
      -H "Accept: application/vnd.github.v3+json" | \
-jq -r '.artifacts[] | select(.name | test("chrome")) | .id'
+jq -r '.artifacts[] | select(.name | test("chrome")) | .id')
 
 if [ -z "$ARTIFACT_ID" ] || [ "$ARTIFACT_ID" = "null" ]; then
     echo "Error: No artifacts found"

--- a/dapp/scripts/download_wallet_artifact.sh
+++ b/dapp/scripts/download_wallet_artifact.sh
@@ -26,7 +26,7 @@ ARTIFACT_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
 jq -r '.workflow_runs[0].artifacts_url' | \
 xargs curl -s -H "Authorization: token $GITHUB_TOKEN" \
      -H "Accept: application/vnd.github.v3+json" | \
-jq -r '.artifacts | min_by(.id) | .id')
+jq -r '.artifacts[] | select(.name | test("chrome")) | .id'
 
 if [ -z "$ARTIFACT_ID" ] || [ "$ARTIFACT_ID" = "null" ]; then
     echo "Error: No artifacts found"


### PR DESCRIPTION
This fixes the CI failing. GitHub probably woke up one day and decide to change how they return the data in their API or something. That caused the script to download the firefox build instead.